### PR TITLE
Add find regisration by reg. number feature

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>uk.gov.ea.wastecarrier</groupId>
     <artifactId>waste-exemplar-services</artifactId>
-    <version>2.2.1-beta</version>
+    <version>2.2.2-beta</version>
     <name>wastecarrier</name>
     <description>Provides a RESTful API for the Waste Carrier registrations</description>
     <properties>

--- a/src/main/java/uk/gov/ea/wastecarrier/services/mongoDb/RegistrationsMongoDao.java
+++ b/src/main/java/uk/gov/ea/wastecarrier/services/mongoDb/RegistrationsMongoDao.java
@@ -8,6 +8,7 @@ import java.util.logging.Logger;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response.Status;
 
+import net.vz.mongodb.jackson.DBQuery;
 import net.vz.mongodb.jackson.JacksonDBCollection;
 import net.vz.mongodb.jackson.WriteResult;
 
@@ -91,6 +92,55 @@ public class RegistrationsMongoDao
 		}
 	
 	}
+
+	public Registration findRegistration(String registrationNumber)
+	{
+		Registration foundReg;
+
+		log.info("Finding registration with reg identifier = " + registrationNumber);
+
+		DB db = databaseHelper.getConnection();
+		if (db != null)
+		{
+			if (!db.isAuthenticated())
+			{
+				log.severe("Find registration - Could not authenticate against MongoDB!");
+				throw new WebApplicationException(Status.FORBIDDEN);
+			}
+
+			// Create MONGOJACK connection to the database
+			JacksonDBCollection<Registration, String> registrations = JacksonDBCollection.wrap(
+					db.getCollection(Registration.COLLECTION_NAME),
+					Registration.class,
+					String.class
+			);
+
+			// Query to find matching reference number
+            DBQuery.Query paramQuery = DBQuery.is("regIdentifier", registrationNumber);
+
+			try
+			{
+				foundReg = registrations.findOne(paramQuery);
+			}
+			catch (IllegalArgumentException e)
+			{
+				log.severe("Caught exception: " + e.getMessage() + " - Cannot find Registration: " + registrationNumber);
+				throw new WebApplicationException(Status.NOT_FOUND);
+			}
+		}
+        else
+        {
+            log.severe("Find registration - Could not obtain connection to MongoDB!");
+            throw new WebApplicationException(Status.SERVICE_UNAVAILABLE);
+        }
+
+		if (foundReg == null)
+		{
+			log.info("Failed to find registration with number: " + registrationNumber);
+			throw new WebApplicationException(Status.NO_CONTENT);
+		}
+		return foundReg;
+	}
 	
 	/**
 	 * Return the registration with the given id
@@ -133,12 +183,7 @@ public class RegistrationsMongoDao
 			throw new WebApplicationException(Status.SERVICE_UNAVAILABLE);
 		}
 	}
-	
-	/**
-	 * Return the registration with the given id
-	 * @param id
-	 * @return
-	 */
+
 	public Registration updateRegistration(Registration reg)
 	{
 		


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-84

To support changes to the front end to properly manage users entering new style registration numbers when trying to renew, we need to be able to confirm if the number entered actually exists.

Surprisingly there was no ability to search for a registration using just its registration number previously. Hence this change adds in support for that kind of search.