### PR TITLE
Add Jenkins pipeline script to the project

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,18 @@
+// Requires the Workspace Cleanup Plugin to be installed before use
+// https://jenkins.io/doc/pipeline/steps/ws-cleanup/
+pipeline {
+    agent { label 'master' }
+    stages {
+        stage('Build project artifacts') {
+            steps {
+                sh "./mvnw -B -DskipTests=true -T 1C clean package"
+            }
+        }
+    }
+    post {
+        always {
+            archiveArtifacts artifacts: 'target/*.jar', onlyIfSuccessful: true
+            cleanWs cleanWhenFailure: false
+        }
+    }
+}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-157

This script is used by our Jenkins instance to build the project. Using pipeline support built into Jenkins it means we can define how the project should be built, and the steps to take in that process in a way that is codified and source controlled.

Essentially a pipepline job is then created in Jenkins that points to this repo, and which will recognise and pick up this script. That is essentially it. No further configuration is needed in the job as it takes its instructions from the script.