### PR TITLE
Incorporate env vars into the configuration.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,20 +31,21 @@ The waste-carriers-frontend application, which is implemented in Ruby on Rails, 
 ## Configuration
 
 The service uses a Dropwizard configuration file (configuration.yml) which in turn refers to environment variables.
-You may want or need to set the following environment variables, e.g. in your ~/.bash_profile (if you are a Mac or Linux user):
+
+You'll need to set the following environment variables before using it. For example
 
 ```bash
-export WCRS_SERVICES_DB_HOST="localhost"
-export WCRS_SERVICES_DB_PORT=27017
-export WCRS_SERVICES_DB_NAME="waste-carriers"
-export WCRS_SERVICES_DB_USER="mongoUser"
-export WCRS_SERVICES_DB_PASSWD="<your-mongo-password>"
+export WCRS_SERVICES_AIRBRAKE_URL="https://myairbrakeinstance.example.com"
+export WCRS_SERVICES_AIRBRAKE_API_KEY="d03r78y5372a11111111111"
+export WCRS_SERVICES_AIRBRAKE_ENVNAME="pre-production"
 ```
+
+Other values in the configuration file have a default, however you can override them by setting the environment variable specified.
 
 Alternatively, you can create another local configuration file with your values in it, and refer to this file when starting up the service.
 
 ```bash
-java -jar target/waste-exemplar-services*.jar server configuration_local.yml
+java -jar target/waste-exemplar-services*.jar server my_configuration.yml
 ```
 
 ## Build
@@ -64,18 +65,18 @@ The normal command on a machine where Maven is installed is `mvn clean package`.
 Start the service by providing the name of the jar file, the command 'server', and the name of the configuration file.
 
 ```bash
-java -jar target/waste-exemplar-services*.jar server  my_configuration.yml
+java -jar target/waste-exemplar-services*.jar server  configuration.yml
 ```
 
 You can also override parameters such as https port numbers using the Java '-D' option.
 
 ```bash
-java -Ddw.http.port=9090 -Ddw.http.adminPort=9091 -jar target/waste-exemplar-services-1.1.2.jar server my_configuration.yml
+java -Ddw.http.port=8004 -Ddw.http.adminPort=8005 -jar target/waste-exemplar-services-1.1.2.jar server my_configuration.yml
 ```
 
 For more details on how to start a Dropwizard service and configuration and startup options, please see the Dropwizard documentation.
 
-Once the application server is started you should be able to access the services application in your browser on <http://localhost:9090/registrations.json>
+Once the application server is started you should be able to access the services application in your browser on <http://localhost:8004/registrations.json>
 
 ## Run Tests
 

--- a/configuration.yml
+++ b/configuration.yml
@@ -14,15 +14,11 @@ logging:
       timeZone: UTC
     # Setting for logging to file
     - type: file
-      # The lowest level of events to write to the file.
-      threshold: INFO
       # The filename where current events are logged.
-      currentLogFilename: run.log
-      # Whether or not to archive old events in separate files.
-      archive: true
+      currentLogFilename: ${WCRS_SERVICES_LOGFILE:-/srv/java/waste-carriers-service/logs/run.log}
       # The filename pattern for archived files. If the pattern ends with
       # .gz or .zip, files will be compressed as they are archived.
-      archivedLogFilenamePattern: run-archive-%d.log.gz
+      archivedLogFilenamePattern: ${WCRS_SERVICES_LOGFILE_PATTERN:-/srv/java/waste-carriers-service/logs/run-archive-%d.log.gz}
       # The number of archived files to keep.
       archivedFileCount: 5
       # The time zone to which event timestamps will be converted.
@@ -35,52 +31,52 @@ server:
   # make the OS use an arbitrary unused port.
   applicationConnectors:
     - type: http
-      port: WCRS_SERVICES_PORT
+      port: 8004
   # The port on which the HTTP server listens for administrative
   # requests. Subject to the same limitations as "port". If this is
   # set to the same value as port, the admin routes will be mounted
   # under /admin.
   adminConnectors:
     - type: http
-      port: WCRS_SERVICES_ADMIN_PORT
+      port: 8005
 
 # added database connection properties, DatabaseConfiguration
 database:
-  host: WCRS_REGSDB_HOST
-  port: WCRS_REGSDB_PORT1
-  name: WCRS_REGSDB_NAME
-  username: WCRS_REGSDB_USERNAME
-  password: WCRS_REGSDB_PASSWORD
+  host: ${WCRS_REGSDB_HOST:-localhost}
+  port: ${WCRS_REGSDB_PORT1:-27017}
+  name: ${WCRS_REGSDB_NAME:-waste-carriers}
+  username: ${WCRS_REGSDB_USERNAME:-mongoUser}
+  password: ${WCRS_REGSDB_PASSWORD:-password1234}
 
 # added user database connection properties, DatabaseConfiguration
 userDatabase:
-  host: WCRS_USERSDB_HOST
-  port: WCRS_USERSDB_PORT1
-  name: WCRS_USERSDB_NAME
-  username: WCRS_USERSDB_USERNAME
-  password: WCRS_USERSDB_PASSWORD
+  host: ${WCRS_USERSDB_HOST:-localhost}
+  port: ${WCRS_USERSDB_PORT1:-27017}
+  name: ${WCRS_USERSDB_NAME:-waste-carriers-users}
+  username: ${WCRS_USERSDB_USERNAME:-mongoUser}
+  password: ${WCRS_USERSDB_PASSWORD:-password1234}
 
 elasticSearch:
-  host: WCRS_ELASDB_HOST
-  port: WCRS_ELASDB_PORT_JAVA
+  host: ${WCRS_ELASDB_HOST:-localhost}
+  port: ${WCRS_ELASDB_PORT_JAVA:-9300}
   # Can also specify a size for the maximum number of results to return in a given query
   # By default the 100 is used, but can be overridden here if specified
   #size: 100
 
 settings:
   # registration period (in years)
-  registrationPeriod: WCRS_REGISTRATION_EXPIRES_AFTER
+  registrationPeriod: ${WCRS_REGISTRATION_EXPIRES_AFTER:-3}
   # renew period (in months)
-  registrationRenewPeriod: WCRS_REGISTRATION_RENEWAL_WINDOW
+  registrationRenewPeriod: ${WCRS_REGISTRATION_RENEWAL_WINDOW:-3}
 
 airbrake:
-  url: WCRS_SERVICES_AIRBRAKE_URL
-  apiKey: WCRS_SERVICES_AIRBRAKE_API_KEY
-  environmentName: WCRS_SERVICES_AIRBRAKE_ENVNAME
+  url: ${WCRS_SERVICES_AIRBRAKE_URL}
+  apiKey: ${WCRS_SERVICES_AIRBRAKE_API_KEY}
+  environmentName: ${WCRS_SERVICES_AIRBRAKE_ENVNAME}
   # The 'threshold' here can take values: OFF, ERROR, WARN, INFO, DEBUG, TRACE
   # or ALL.  If no value is provided, or the value is unrecognised, by default
   # we only forward messages at ERROR severity.
-  threshold: WCRS_SERVICES_AIRBRAKE_THRESHOLD 
+  threshold: ${WCRS_SERVICES_AIRBRAKE_THRESHOLD:-ERROR}
   # Other values you can set for Airbrake integration, but not required:
   # enabled: true or false (default = true)
   # exceptionsOnly: true or false (default = false)
@@ -88,24 +84,24 @@ airbrake:
 # IrRenewals brings a very limitted set of data into Waste Carriers to allow
 # IR customers to "renew" in the service.
 irRenewals:
-  irFolderPath: WCRS_SERVICES_IR_RENEWAL_FOLDERPATH
+  irFolderPath: ${WCRS_SERVICES_IR_RENEWAL_FOLDERPATH:-/srv/java/waste-carriers-service/irdata/}
 
 exportJob:
   # File to use for EPR exports (note: file, not directory).
-  eprExportFile: WCRS_SERVICES_EPR_EXPORT_FILE
+  eprExportFile: ${WCRS_SERVICES_EPR_EXPORT_FILE:-/srv/java/waste-carriers-service/exports/waste-carriers-epr.csv}
   # Date format to use for EPR exports.
   eprExportDateFormat: "yyyy-MM-dd"
   # Path to use for Reporting Snapshot exports (note: directory, not file).
-  reportingExportPath: WCRS_SERVICES_REPORTING_EXPORT_PATH
+  reportingExportPath: ${WCRS_SERVICES_REPORTING_EXPORT_PATH:-/srv/java/waste-carriers-service/exports}
   # Date format to use for Reporting Snapshot exports.
   reportingExportDateFormat: "yyyy-MM-dd'T'HH:mm'Z'"
   # Money format to use for Reporting Snapshot exports.
   reportingExportMoneyFormat: "0.00"
-  # Cron expression for scheduled job exectuion.  Leave empty to make the job
+  # Cron expression for scheduled job execution.  Leave empty to make the job
   # run on a manual trigger only.  Default is daily at 9pm.
-  cronExpression: WCRS_SERVICES_EXPORT_JOB_CRON_SCHEDULE
+  cronExpression: ${WCRS_SERVICES_EXPORT_JOB_CRON_SCHEDULE:-30 0/15 * * * ?}
 
 registrationStatusJob:
   # Cron expression for scheduled job exectuion.  Leave empty to make the job
   # run on a manual trigger only.  Default is daily at 8pm.
-  cronExpression: WCRS_SERVICES_STATUS_JOB_CRON_SCHEDULE
+  cronExpression: ${WCRS_SERVICES_STATUS_JOB_CRON_SCHEDULE:-0 0/15 * * * ?}

--- a/src/main/java/uk/gov/ea/wastecarrier/services/WasteCarrierService.java
+++ b/src/main/java/uk/gov/ea/wastecarrier/services/WasteCarrierService.java
@@ -3,6 +3,8 @@ package uk.gov.ea.wastecarrier.services;
 import java.io.PrintWriter;
 import java.util.logging.Logger;
 
+import io.dropwizard.configuration.EnvironmentVariableSubstitutor;
+import io.dropwizard.configuration.SubstitutingSourceProvider;
 import org.elasticsearch.client.Client;
 
 import uk.gov.ea.wastecarrier.services.cli.IRImporter;
@@ -67,6 +69,13 @@ public class WasteCarrierService extends Application<WasteCarrierConfiguration>
     @Override
     public void initialize(Bootstrap<WasteCarrierConfiguration> bootstrap)
     {
+        bootstrap.setConfigurationSourceProvider(
+                new SubstitutingSourceProvider(
+                        bootstrap.getConfigurationSourceProvider(),
+                        new EnvironmentVariableSubstitutor(false)
+                )
+        );
+
         // Add a command to import IR registrations.
         // This can only be performed when the server is NOT running.
         bootstrap.addCommand(new IRImporter());


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-157

To improve how the service can be deployed rather than have to hard code various values into a config file (specifically database username and passwords) and then store that file elsewhere, we've taken advantage of the upgrade in the Dropwizard framework to use environment variable substitution.

Depending on where the app is deployed to (either vagrant or an AWS environment) you'll need to set certain environment variables to match as some of the defaults are for a specific environment.

What it does now mean though, as long as those environment variables are set by the environments provisioning scripts, we can start the service with the `configuration.yml` file included in the project.