### PR TITLE
Ensure config.yml is archived in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,6 +12,7 @@ pipeline {
     post {
         always {
             archiveArtifacts artifacts: 'target/*.jar', onlyIfSuccessful: true
+            archiveArtifacts artifacts: 'configuration.yml', onlyIfSuccessful: true
             cleanWs cleanWhenFailure: false
         }
     }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-157

As we can now use the config file that is included with the project rather than a special one with pre-populated values we need to ensure its archived along with the .jar when we run the build in Jenkins.