### PR TITLE
Fix issue with artifact and proj name diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Other values in the configuration file have a default, however you can override 
 Alternatively, you can create another local configuration file with your values in it, and refer to this file when starting up the service.
 
 ```bash
-java -jar target/waste-exemplar-services*.jar server my_configuration.yml
+java -jar target/waste-carriers-service*.jar server my_configuration.yml
 ```
 
 ## Build
@@ -65,13 +65,13 @@ The normal command on a machine where Maven is installed is `mvn clean package`.
 Start the service by providing the name of the jar file, the command 'server', and the name of the configuration file.
 
 ```bash
-java -jar target/waste-exemplar-services*.jar server  configuration.yml
+java -jar target/waste-carriers-service*.jar server  configuration.yml
 ```
 
 You can also override parameters such as https port numbers using the Java '-D' option.
 
 ```bash
-java -Ddw.http.port=8004 -Ddw.http.adminPort=8005 -jar target/waste-exemplar-services-1.1.2.jar server my_configuration.yml
+java -Ddw.http.port=8004 -Ddw.http.adminPort=8005 -jar target/waste-carriers-service-1.1.2.jar server my_configuration.yml
 ```
 
 For more details on how to start a Dropwizard service and configuration and startup options, please see the Dropwizard documentation.

--- a/pom.xml
+++ b/pom.xml
@@ -1,9 +1,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>uk.gov.ea.wastecarrier</groupId>
-    <artifactId>waste-exemplar-services</artifactId>
+    <artifactId>waste-carriers-service</artifactId>
     <version>3.0.0-beta</version>
-    <name>wastecarrier</name>
+    <name>waste-carriers-service</name>
     <description>Provides a RESTful API for the Waste Carrier registrations</description>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/uk/gov/ea/wastecarrier/services/WasteCarrierService.java
+++ b/src/main/java/uk/gov/ea/wastecarrier/services/WasteCarrierService.java
@@ -63,7 +63,7 @@ public class WasteCarrierService extends Application<WasteCarrierConfiguration>
 
     @Override
     public String getName() {
-        return "wastecarrier-services";
+        return "waste-carriers-service";
     }
 
     @Override


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-157

There has always been a disconnect between the name of the project and the name of the fat jar it generates when built.

As we are about to move it to a new environment we are taking this opportunity to fix the difference between the two.