### PR TITLE
OriginalRegNumberSearch should only return 1 reg.

### DIFF
--- a/src/main/java/uk/gov/ea/wastecarrier/services/resources/SearchResource.java
+++ b/src/main/java/uk/gov/ea/wastecarrier/services/resources/SearchResource.java
@@ -4,7 +4,6 @@ import com.google.common.base.Optional;
 import com.mongodb.MongoException;
 import org.hibernate.validator.constraints.NotEmpty;
 import uk.gov.ea.wastecarrier.services.DatabaseConfiguration;
-import uk.gov.ea.wastecarrier.services.SettingsConfiguration;
 import uk.gov.ea.wastecarrier.services.core.Registration;
 import uk.gov.ea.wastecarrier.services.mongoDb.*;
 import uk.gov.ea.wastecarrier.services.search.*;
@@ -205,11 +204,11 @@ public class SearchResource {
 
     @GET
     @Path("/original/{originalRegistrationNumber}")
-    public List<Registration> queryOriginalRegNumber(
+    public Registration queryOriginalRegNumber(
             @PathParam("originalRegistrationNumber") String originalRegNumber
     ) {
         log.fine("Get Method Detected at /search/originalRegistrationNumber");
-        List<Registration> searchResults;
+        Registration searchResult;
 
         try {
             OriginalRegNumberSearch search = new OriginalRegNumberSearch(
@@ -217,12 +216,12 @@ public class SearchResource {
                     originalRegNumber
             );
 
-            searchResults = search.execute();
+            searchResult = search.execute();
         } catch (MongoException e) {
             log.severe("Query error: " + e.getMessage());
             throw new WebApplicationException(Response.Status.SERVICE_UNAVAILABLE);
         }
 
-        return searchResults;
+        return searchResult;
     }
 }

--- a/src/main/java/uk/gov/ea/wastecarrier/services/search/OriginalRegNumberSearch.java
+++ b/src/main/java/uk/gov/ea/wastecarrier/services/search/OriginalRegNumberSearch.java
@@ -4,8 +4,6 @@ import org.mongojack.DBQuery;
 import org.mongojack.JacksonDBCollection;
 import uk.gov.ea.wastecarrier.services.core.Registration;
 
-import java.util.LinkedList;
-import java.util.List;
 import java.util.logging.Logger;
 
 public class OriginalRegNumberSearch {
@@ -29,21 +27,21 @@ public class OriginalRegNumberSearch {
         this.originalRegNumber = originalRegNumber;
     }
 
-    public List<Registration> execute() {
+    public Registration execute() {
 
         JacksonDBCollection<Registration, String> registrations = this.searchHelper.registrationsCollection();
 
         // Query to find registrations with matching accountEmail
         DBQuery.Query query = DBQuery.is("originalRegistrationNumber", this.originalRegNumber);
 
-        List<Registration> results = new LinkedList<>();
+        Registration result = null;
 
         try {
-            results = searchHelper.toList(registrations.find(query));
+            result = registrations.findOne(query);
         } catch (IllegalArgumentException e) {
             log.severe("Caught exception: " + e.getMessage() + " - Cannot find originalRegistrationNumber " + this.originalRegNumber);
         }
 
-        return results;
+        return result;
     }
 }

--- a/src/test/java/uk/gov/ea/wastecarrier/services/OriginalRegNumberSearchTest.java
+++ b/src/test/java/uk/gov/ea/wastecarrier/services/OriginalRegNumberSearchTest.java
@@ -5,8 +5,6 @@ import uk.gov.ea.wastecarrier.services.core.Registration;
 import uk.gov.ea.wastecarrier.services.search.OriginalRegNumberSearch;
 import uk.gov.ea.wastecarrier.services.support.*;
 
-import java.util.List;
-
 import static org.junit.Assert.assertEquals;
 
 public class OriginalRegNumberSearchTest {
@@ -31,9 +29,10 @@ public class OriginalRegNumberSearchTest {
     @Test
     public void searchForRegistration() {
         OriginalRegNumberSearch search = new OriginalRegNumberSearch(connection.searchHelper, originalRegNumber);
-        List<Registration> results = search.execute();
-        String resultOriginalRegNo = results.get(0).getOriginalRegistrationNumber();
-        assertEquals("Matching registrations are found", originalRegNumber, resultOriginalRegNo);
+
+        Registration result = search.execute();
+
+        assertEquals("Matching registrations are found", originalRegNumber, result.getOriginalRegistrationNumber());
     }
 
     /**


### PR DESCRIPTION
Obviously a result of being to aggresive with the cut and paste, prior to this change `OriginalRegNumberSearch` was returning a list of registrations.

However the calling method in the front end is only ever expecting one result hence was erroring.

This change updates the search to match the expected behaviour.