### PR TITLE
Remove skip test in pom.xml & use cmd arg instead

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,13 @@ pipeline {
     stages {
         stage('Build project artifacts') {
             steps {
-                sh "./mvnw -B -DskipTests=true -T 1C clean package"
+                // Options are
+                // -B: Run in non-interactive (batch) mode
+                // -D: Define a system property (in this case skip compiling and running tests
+                // -T 1C: Thread count which means run single threaded
+                // clean: remove files from a previous build
+                // package: take the compiled code and package it into a fat JAR
+                sh "./mvnw -B -Dmaven.test.skip=true -T 1C clean package"
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -54,10 +54,10 @@ The project uses [Maven](https://maven.apache.org/) as its build tool, and [Mave
 So to build the project call
 
 ```bash
-./mvnw clean package
+./mvnw -B -Dmaven.test.skip=true -T 1C clean package
 ```
 
-The normal command on a machine where Maven is installed is `mvn clean package`.
+N.B. If maven was installed all on the machine you would swap `./mvnw` with `mvn`.
 
 ## Startup
 
@@ -79,14 +79,19 @@ Once the application server is started you should be able to access the services
 
 ## Run Tests
 
-The project doesn't have an extensive suite of unit tests, but is working to improve its test coverage. It also relies on specific test environment variables existing for them to run. As such they are not run automatically during a maven build (`mvn package`) but can be called manually. Before running the tests though you need to have sourced the environment variables. This is because the unit tests can't read from the config file so key details about MongoDb need to be provided as environment variables.
+The project doesn't have an extensive suite of unit tests, but is working to improve its test coverage. They require a working connection to MongoDb, and specific test environment variables existing for them to run. Before running the tests you'll need to have sourced the environment variables. This is because the unit tests can't read from the config file so key details about MongoDb need to be provided as environment variables.
 
 ```bash
 source test_env_vars.sh
-mvn test
 ```
 
 Once you've run the environment variable script, you won't need to do it again until you open a new terminal session.
+
+Hence the command to build above includes the option to skip tests. Instead we advise those working on the project should manually run the tests as and when required using
+
+```bash
+./mvnw test
+```
 
 ## Postcode data
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <dropwizard.version>1.3.1</dropwizard.version>
-        <maven.test.skip>true</maven.test.skip>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
Because the project requires a connection to MongoDB in order to run the build, this can make it a problem in CI and Jenkins jobs where that access may not be available.

So to prevent issues when building we added a skip test flag to the pom.xml, however we then found we could not get `mvn test` to run either.

Plus expected behaviour is that the tests would automatically run hence we've decided to update the project to remove the flag and instead use a command line option to govern when whether tests should be run as part of a build.

This makes it more explicit and ensures the project behaves as expected.