### PR TITLE
Handle names with periods in CompanyMatch

### DIFF
--- a/src/main/java/uk/gov/ea/wastecarrier/services/match/CompanyMatch.java
+++ b/src/main/java/uk/gov/ea/wastecarrier/services/match/CompanyMatch.java
@@ -113,13 +113,22 @@ public class CompanyMatch {
 
     private String parseName(String name) {
 
-        if (name == null || name.trim().isEmpty()) return "";
+        if (name == null) return "";
+
+        name = name.trim();
+        if (name.isEmpty()) return "";
+
+        // Check for a period on the end. Not doing so means the match could
+        // be confused by something like 'Test Waste Ltd.' because 'Ltd.'
+        // won't be caught by ignored words check, and it might be that in the
+        // db the record is held as 'Ltd' or 'Limited'.
+        if (name.endsWith(".")) name = name.substring(0, name.length() - 1);
 
         StringBuilder parsedName = new StringBuilder();
 
         for (String word: Arrays.asList(name.toLowerCase().split(" "))) {
             if (!word.isEmpty() && !ignoredNameWords.contains(word)) {
-                parsedName.append(word + ' ');
+                parsedName.append(word).append(" ");
             }
         }
 

--- a/src/test/java/uk/gov/ea/wastecarrier/services/CompanyMatchTest.java
+++ b/src/test/java/uk/gov/ea/wastecarrier/services/CompanyMatchTest.java
@@ -79,6 +79,16 @@ public class CompanyMatchTest {
     }
 
     @Test
+    public void nameMatchEndsWithPeriod() {
+        CompanyMatch matcher = new CompanyMatch(connection.searchHelper, "Isaacs Waste Services Ltd.", null);
+
+        Entity document = matcher.execute();
+
+        assertNotNull(document);
+        assertEquals("Company with name of 'Isaacs Waste Contractors Ltd' is found", "Isaacs Waste Contractors Ltd", document.name);
+    }
+
+    @Test
     public void numberMatchExact() {
         CompanyMatch matcher = new CompanyMatch(connection.searchHelper, null, "12345678");
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-342

During testing of the new entity matching features it was highlighted that querying for 'Test Waste Services Ltd.' didn't match with a 'Test Waste Services Ltd'.

It was all down to the end period, and to guard against it in future the `CompanyMatch` now strips any periods of the end of names passed in.