### PR TITLE
Standardise Airbrake url env var name

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ The service uses a Dropwizard configuration file (configuration.yml) which in tu
 You'll need to set the following environment variables before using it. For example
 
 ```bash
-export WCRS_SERVICES_AIRBRAKE_HOST="https://myairbrakeinstance.example.com"
 export WCRS_SERVICES_AIRBRAKE_PROJECT_KEY="d03r78y5372a11111111111"
 export WCRS_SERVICES_AIRBRAKE_ENVNAME="pre-production"
 ```

--- a/configuration.yml
+++ b/configuration.yml
@@ -79,7 +79,7 @@ settings:
   searchResultCount: ${WCRS_SERVICE_SEARCH_RESULT_COUNT:-50}
 
 airbrake:
-  url: ${WCRS_SERVICES_AIRBRAKE_HOST}
+  url: ${WCRS_AIRBRAKE_URL}
   apiKey: ${WCRS_SERVICES_AIRBRAKE_PROJECT_KEY}
   environmentName: ${WCRS_SERVICES_AIRBRAKE_ENVNAME}
   # The 'threshold' here can take values: OFF, ERROR, WARN, INFO, DEBUG, TRACE


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-281

Spotted that each app had its own env var for hold the url of the Errbit instance to send exceptions to, but that they were all the same.

In review we would want to point an environment on mass to a particular Errbit instance, not just individual apps so this change is part of a number of changes across the apps to use the same env var for the Errbit instance url.