### PR TITLE
Fix error with background job config

### DIFF
--- a/src/main/java/uk/gov/ea/wastecarrier/services/DatabaseConfiguration.java
+++ b/src/main/java/uk/gov/ea/wastecarrier/services/DatabaseConfiguration.java
@@ -49,7 +49,7 @@ public class DatabaseConfiguration {
     }
 
     public String getUrl() {
-        return host;
+        return this.url;
     }
 
     public String getHost() {

--- a/src/main/java/uk/gov/ea/wastecarrier/services/backgroundJobs/BackgroundJobScheduler.java
+++ b/src/main/java/uk/gov/ea/wastecarrier/services/backgroundJobs/BackgroundJobScheduler.java
@@ -177,6 +177,8 @@ public class BackgroundJobScheduler implements Managed
 
         JobDataMap dataMap = exportJob.getJobDataMap();
         dataMap.put(ExportJob.DATABASE_URL, databaseConfig.getUrl());
+        dataMap.put(ExportJob.DATABASE_HOST, databaseConfig.getHost());
+        dataMap.put(ExportJob.DATABASE_PORT, databaseConfig.getPort());
         dataMap.put(ExportJob.DATABASE_NAME, databaseConfig.getName());
         dataMap.put(ExportJob.DATABASE_USERNAME, databaseConfig.getUsername());
         dataMap.put(ExportJob.DATABASE_PASSWORD, databaseConfig.getPassword());
@@ -216,6 +218,8 @@ public class BackgroundJobScheduler implements Managed
         
         JobDataMap dataMap = regStatusJob.getJobDataMap();
         dataMap.put(RegistrationStatusJob.DATABASE_URL, databaseConfig.getUrl());
+        dataMap.put(RegistrationStatusJob.DATABASE_HOST, databaseConfig.getHost());
+        dataMap.put(RegistrationStatusJob.DATABASE_PORT, databaseConfig.getPort());
         dataMap.put(RegistrationStatusJob.DATABASE_NAME, databaseConfig.getName());
         dataMap.put(RegistrationStatusJob.DATABASE_USERNAME, databaseConfig.getUsername());
         dataMap.put(RegistrationStatusJob.DATABASE_PASSWORD, databaseConfig.getPassword());

--- a/src/main/java/uk/gov/ea/wastecarrier/services/backgroundJobs/ExportJob.java
+++ b/src/main/java/uk/gov/ea/wastecarrier/services/backgroundJobs/ExportJob.java
@@ -47,6 +47,8 @@ public class ExportJob implements Job
     // Public 'constants' used in the JobDataMap, which passes configuration
     // to this job.
     public static final String DATABASE_URL = "database_url";
+    public static final String DATABASE_HOST = "database_host";
+    public static final String DATABASE_PORT = "database_port";
     public static final String DATABASE_NAME = "database_name";
     public static final String DATABASE_USERNAME = "database_username";
     public static final String DATABASE_PASSWORD = "database_password";

--- a/src/main/java/uk/gov/ea/wastecarrier/services/backgroundJobs/RegistrationStatusJob.java
+++ b/src/main/java/uk/gov/ea/wastecarrier/services/backgroundJobs/RegistrationStatusJob.java
@@ -33,6 +33,8 @@ public class RegistrationStatusJob implements Job
     // Public 'constants' used in the JobDataMap, which passes configuration
     // to this job.
     public static final String DATABASE_URL = "database_url";
+    public static final String DATABASE_HOST = "database_host";
+    public static final String DATABASE_PORT = "database_port";
     public static final String DATABASE_NAME = "database_name";
     public static final String DATABASE_USERNAME = "database_username";
     public static final String DATABASE_PASSWORD = "database_password";


### PR DESCRIPTION
In further testing following the env var standardisation we spotted that the `DatabaseConfiguration.getUrl()` method was actually returning the url property.

This was then causing an error when the background jobs were being scheduled.

This change fixes it. We also add back in references to host and port to the jobs data maps just in case.