### PR TITLE
Add ability to mock Worldpay to service

### DIFF
--- a/configuration.yml
+++ b/configuration.yml
@@ -120,3 +120,25 @@ registrationStatusJob:
   # Cron expression for scheduled job execution. Leave empty to make the job
   # run on a manual trigger only.  Default is daily at 8pm.
   cronExpression: ${WCRS_STATUS_JOB_CRON_SCHEDULE:-0 0/15 * * * ?}
+
+mock:
+  # Once a payment is complete with worldpay it redirects the user to the
+  # original client. In that redirection it passes a number of params of which
+  # an admin code is one of them. As we don't receive it in any requests from
+  # the client, we have to pull it from the environment
+  worldPayAdminCode: ${WCRS_WORLDPAY_ADMIN_CODE:-ENVIRONMENTAGENCY}
+  # Upon receiving the initial request from a service using worldpay, we have
+  # to generate a url that the client should redirect the user to. So we need
+  # to know what our own url is within the current environment
+  servicesDomain: ${WCRS_SERVICES_DOMAIN:-http://localhost:8003}
+  # The mac secret is a password shared only between Worldpay and its customers.
+  # Its used along with some information from the order to sign the success
+  # response. In this way the client is sure its worldpay telling them the user
+  # has completed payment and no one else. So again we need to grab this from
+  # the environment.
+  macSecret: ${WCRS_WORLDPAY_ECOM_MACSECRET:-macKeydaddyyeahfool@7}
+  # To try and more closely mock calling out to Worldpay you can have the
+  # service pause during each call. The default is a best guess at trying to
+  # and take into account reading from the xml files/generating responses whilst
+  # delaying enough to mimic a normal call to the service
+  delay: ${WCRS_MOCK_DELAY:-200}

--- a/src/main/java/uk/gov/ea/wastecarrier/services/EntityMatchingConfiguration.java
+++ b/src/main/java/uk/gov/ea/wastecarrier/services/EntityMatchingConfiguration.java
@@ -5,8 +5,6 @@ import io.dropwizard.Configuration;
 import org.hibernate.validator.constraints.NotEmpty;
 
 import javax.validation.Valid;
-import javax.validation.constraints.Max;
-import javax.validation.constraints.Min;
 
 public class EntityMatchingConfiguration extends Configuration {
 

--- a/src/main/java/uk/gov/ea/wastecarrier/services/MockConfiguration.java
+++ b/src/main/java/uk/gov/ea/wastecarrier/services/MockConfiguration.java
@@ -1,0 +1,29 @@
+package uk.gov.ea.wastecarrier.services;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.dropwizard.Configuration;
+import org.hibernate.validator.constraints.NotEmpty;
+
+import javax.validation.Valid;
+
+public class MockConfiguration extends Configuration {
+
+    @Valid
+    @NotEmpty
+    @JsonProperty
+    public String worldPayAdminCode;
+
+    @Valid
+    @NotEmpty
+    @JsonProperty
+    public String servicesDomain;
+
+    @Valid
+    @NotEmpty
+    @JsonProperty
+    public String macSecret;
+
+    @Valid
+    @JsonProperty
+    public Integer delay;
+}

--- a/src/main/java/uk/gov/ea/wastecarrier/services/WasteCarrierConfiguration.java
+++ b/src/main/java/uk/gov/ea/wastecarrier/services/WasteCarrierConfiguration.java
@@ -52,9 +52,14 @@ public class WasteCarrierConfiguration extends Configuration {
     private RegistrationStatusJobConfiguration registrationStatusJob = new RegistrationStatusJobConfiguration();
     
     @Valid
+    @NotNull
     @JsonProperty
     private AirbrakeLogbackConfiguration airbrake = new AirbrakeLogbackConfiguration();
 
+    @Valid
+    @NotNull
+    @JsonProperty
+    private MockConfiguration mock = new MockConfiguration();
     
     public DatabaseConfiguration getDatabase() {
         return database;
@@ -90,5 +95,9 @@ public class WasteCarrierConfiguration extends Configuration {
     
     public AirbrakeLogbackConfiguration getAirbrakeLogbackConfiguration() {
         return airbrake;
+    }
+
+    public MockConfiguration getMockConfiguration() {
+        return mock;
     }
 }

--- a/src/main/java/uk/gov/ea/wastecarrier/services/core/mocks/WorldpayOrder.java
+++ b/src/main/java/uk/gov/ea/wastecarrier/services/core/mocks/WorldpayOrder.java
@@ -1,0 +1,42 @@
+package uk.gov.ea.wastecarrier.services.core.mocks;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.mongojack.Id;
+import org.mongojack.ObjectId;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class WorldpayOrder {
+
+    @JsonProperty
+    @Id
+    @ObjectId
+    public String id;
+
+    @JsonProperty
+    public String worldpayId;
+
+    @JsonProperty
+    public String merchantCode;
+
+    @JsonProperty
+    public String orderCode;
+
+    @JsonProperty
+    public String description;
+
+    @JsonProperty
+    public String currencyCode;
+
+    @JsonProperty
+    public Integer value;
+
+    @JsonProperty
+    public String exponent;
+
+    @JsonProperty
+    public String orderContent;
+
+    @JsonProperty
+    public String shopperEmailAddress;
+}

--- a/src/main/java/uk/gov/ea/wastecarrier/services/dao/MockWorldpayDao.java
+++ b/src/main/java/uk/gov/ea/wastecarrier/services/dao/MockWorldpayDao.java
@@ -1,0 +1,93 @@
+package uk.gov.ea.wastecarrier.services.dao;
+
+import com.mongodb.DB;
+import org.mongojack.DBQuery;
+import org.mongojack.JacksonDBCollection;
+import org.mongojack.WriteResult;
+import uk.gov.ea.wastecarrier.services.DatabaseConfiguration;
+import uk.gov.ea.wastecarrier.services.core.mocks.WorldpayOrder;
+import uk.gov.ea.wastecarrier.services.helper.DatabaseHelper;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response.Status;
+import java.util.logging.Logger;
+
+public class MockWorldpayDao implements ICanGetCollection<WorldpayOrder> {
+
+    public static final String COLLECTION_NAME = "mock-worldpay-orders";
+
+    private DatabaseHelper databaseHelper;
+
+    private static Logger log = Logger.getLogger(MockWorldpayDao.class.getName());
+
+    public MockWorldpayDao(DatabaseConfiguration database) {
+        this.databaseHelper = new DatabaseHelper(database);
+    }
+
+    public boolean checkConnection() {
+        return getCollection().count() >= 0;
+    }
+
+    public WorldpayOrder find(String id) {
+        return find(getCollection(), id);
+    }
+
+    public WorldpayOrder findByOrderCode(String orderCode) {
+
+        JacksonDBCollection<WorldpayOrder, String> collection = getCollection();
+
+        WorldpayOrder found;
+
+        DBQuery.Query paramQuery = DBQuery.is("orderCode", orderCode);
+
+        try {
+            found = collection.findOne(paramQuery);
+        } catch (IllegalArgumentException e) {
+            log.severe("Error finding WorldpayOrder " + orderCode + ": "  + e.getMessage());
+            throw new WebApplicationException(Status.NOT_FOUND);
+        }
+
+        if (found == null) {
+            log.info("Failed to find WorldpayOrder " + orderCode);
+            throw new WebApplicationException(Status.NO_CONTENT);
+        }
+
+        return found;
+    }
+
+    public WorldpayOrder insert(WorldpayOrder entity) {
+
+        JacksonDBCollection<WorldpayOrder, String> collection = getCollection();
+
+        // Insert entity information into database
+        WriteResult<WorldpayOrder, String> result = collection.insert(entity);
+
+        // Get unique ID out of response, and find updated record
+        String id = result.getSavedId();
+
+        return find(collection, id);
+    }
+
+    public JacksonDBCollection<WorldpayOrder, String> getCollection() {
+
+        DB db = this.databaseHelper.getConnection();
+
+        if (db == null) {
+            log.severe("Could not establish database connection to MongoDB! Check the database is running");
+            throw new WebApplicationException(Status.SERVICE_UNAVAILABLE);
+        }
+
+        return JacksonDBCollection.wrap(
+                db.getCollection(COLLECTION_NAME), WorldpayOrder.class, String.class);
+    }
+
+    private WorldpayOrder find(JacksonDBCollection<WorldpayOrder, String> collection, String id) {
+
+        try {
+            return collection.findOneById(id);
+        } catch (IllegalArgumentException e) {
+            log.severe("Error finding WorldpayOrder ID " + id + ": " + e.getMessage());
+            throw new WebApplicationException(Status.NOT_FOUND);
+        }
+    }
+}

--- a/src/main/java/uk/gov/ea/wastecarrier/services/helper/ResourceHelper.java
+++ b/src/main/java/uk/gov/ea/wastecarrier/services/helper/ResourceHelper.java
@@ -1,0 +1,59 @@
+package uk.gov.ea.wastecarrier.services.helper;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.logging.Logger;
+
+public class ResourceHelper {
+
+    private ClassLoader loader;
+
+    private static Logger log = Logger.getLogger(ResourceHelper.class.getName());
+
+    public ResourceHelper() {
+        this.loader = this.getClass().getClassLoader();
+    }
+
+    public String openResourceFile(String path, String name) {
+
+        String content = null;
+
+        InputStream inputStream = loader.getResourceAsStream(pathToResource(path, name));
+
+        if (inputStream != null) content = resourceToString(inputStream);
+
+        return content;
+    }
+
+    private String pathToResource(String path, String name) {
+        return String.format(
+                "%s/%s",
+                path,
+                name.replaceAll(" ", "")
+        );
+    }
+
+    private String resourceToString(InputStream inputStream) {
+
+        StringBuilder content = new StringBuilder();
+
+        try {
+            BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
+
+            String line;
+
+            while((line = reader.readLine()) != null) {
+                content.append(line).append("\n");
+            }
+
+            reader.close();
+            inputStream.close();
+        } catch (IOException ex) {
+            log.severe("ResourceHelper - error converting resource to string: " + ex.getMessage());
+        }
+
+        return content.toString();
+    }
+}

--- a/src/main/java/uk/gov/ea/wastecarrier/services/helper/WorldpayHelper.java
+++ b/src/main/java/uk/gov/ea/wastecarrier/services/helper/WorldpayHelper.java
@@ -1,0 +1,167 @@
+package uk.gov.ea.wastecarrier.services.helper;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.xml.sax.InputSource;
+import uk.gov.ea.wastecarrier.services.core.mocks.WorldpayOrder;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.StringReader;
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.logging.Logger;
+
+public class WorldpayHelper {
+
+    private static final String RESOURCE_PATH = "mocks/worldpay";
+
+    private final String adminCode;
+    private final String serviceDomain;
+    private final String macSecret;
+    private final ResourceHelper resourceHelper;
+
+    private Logger log = Logger.getLogger(WorldpayHelper.class.getName());
+
+    public WorldpayHelper(String adminCode, String serviceDomain, String macSecret) {
+        this.adminCode = adminCode;
+        this.serviceDomain = serviceDomain;
+        this.macSecret = macSecret;
+        this.resourceHelper = new ResourceHelper();
+    }
+
+    public Document stringToXml(String value) {
+        Document result = null;
+
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder builder;
+
+        try {
+            builder = factory.newDocumentBuilder();
+            result = builder.parse(new InputSource(new StringReader(value)));
+
+            // Optional, but recommended
+            // http://stackoverflow.com/questions/13786607/normalization-in-dom-parsing-with-java-how-does-it-work
+            result.getDocumentElement().normalize();
+        } catch (Exception ex) {
+            log.severe("Error parsing XML: " + ex.getMessage());
+        }
+
+        return result;
+    }
+
+    public String initialResponse(String merchantCode, String orderCode, String id) {
+
+        String template = this.resourceHelper.openResourceFile(RESOURCE_PATH, "initialResponse.xml");
+        String url = this.serviceDomain + "/mocks/worldpay/dispatcher";
+
+        String response = template.replaceAll("MERCHANT_CODE", merchantCode);
+        response = response.replaceFirst("WORLDPAY_ID", id);
+        response = response.replaceFirst("WORLDPAY_URL", url);
+
+        return response.replaceAll("ORDER_CODE", orderCode);
+    }
+
+    public String orderCompletedRedirectUrl(WorldpayOrder order, String successUrl) {
+
+        String queryString = String.format(
+                "?orderKey=%s&paymentStatus=AUTHORISED&paymentAmount=%s&paymentCurrency=%s&mac=%s&source=WP",
+                generateOrderKey(order).replaceAll("\\^","%5E"),
+                String.valueOf(order.value),
+                order.currencyCode,
+                generateMac(order)
+        );
+
+        return successUrl + queryString;
+    }
+
+    public String extractOrderCodeFromKey(String orderKey) {
+        return orderKey.split("\\^")[1];
+    }
+
+    public WorldpayOrder convertFromXml(Document xmlOrder) {
+
+        WorldpayOrder order = new WorldpayOrder();
+
+        order.worldpayId = generateWorldPayId();
+
+        order.merchantCode = xmlOrder.getDocumentElement().getAttribute("merchantCode");
+
+        Element eOrder = ((Element) xmlOrder.getElementsByTagName("order").item(0));
+
+        order.orderCode = eOrder.getAttribute("orderCode");
+        order.description = eOrder.getElementsByTagName("description").item(0).getTextContent();
+        order.orderContent = eOrder.getElementsByTagName("orderContent").item(0).getTextContent();
+
+        Element amount = (Element) eOrder.getElementsByTagName("amount").item(0);
+
+        order.currencyCode = amount.getAttribute("currencyCode");
+        order.value = Integer.valueOf(amount.getAttribute("value"));
+        order.exponent = amount.getAttribute("exponent");
+
+        Element shopper = (Element) eOrder.getElementsByTagName("shopper").item(0);
+
+        order.shopperEmailAddress = shopper.getElementsByTagName("shopperEmailAddress").item(0).getTextContent();
+
+        return order;
+    }
+
+    public String generateWorldPayId() {
+        // https://stackoverflow.com/a/5328933/6117745
+        return String.valueOf((long) Math.floor(Math.random() * 9_000_000_000L) + 1_000_000_000L);
+    }
+
+    /**
+     * From the order details and config settings generate the mac code used to
+     * sign a response from worldpay
+     *
+     * Started by following the advice in
+     * http://support.worldpay.com/support/kb/gg/corporate-gateway-guide/content/hostedintegration/securingpayments.htm
+     * and looked at
+     * https://stackoverflow.com/questions/7124735/hmac-sha256-algorithm-for-signature-calculation
+     * https://github.com/danharper/hmac-examples
+     *
+     * However they were returning values nothing like what we were seeing from
+     * Worldpay. So following what the Frontend and Renewals apps do, we looked
+     * instead at MD5. Using the code below we finally were generating values
+     * in the same way as Worldpay.
+     *
+     * Solution taken from
+     * https://stackoverflow.com/a/30119004/6117745
+     * @param order Order to generate the mac for
+     * @return a string representing the encoded mac
+     */
+    public String generateMac(WorldpayOrder order) {
+        String result = null;
+
+        String message = String.format(
+                "%s%s%sAUTHORISED%s",
+                generateOrderKey(order),
+                String.valueOf(order.value),
+                order.currencyCode,
+                this.macSecret
+        );
+
+        try {
+            MessageDigest md5 = MessageDigest.getInstance("MD5");
+            md5.update(StandardCharsets.UTF_8.encode(message));
+
+            result = String.format("%032x", new BigInteger(1, md5.digest()));
+        } catch(NoSuchAlgorithmException ex) {
+            log.severe("Error generating Mac: " + ex.getMessage());
+        }
+
+        return result;
+    }
+
+    private String generateOrderKey(WorldpayOrder order) {
+        return String.format(
+                "%s^%s^%s",
+                this.adminCode,
+                order.merchantCode,
+                order.orderCode
+        );
+    }
+}

--- a/src/main/java/uk/gov/ea/wastecarrier/services/resources/MocksResource.java
+++ b/src/main/java/uk/gov/ea/wastecarrier/services/resources/MocksResource.java
@@ -1,0 +1,78 @@
+package uk.gov.ea.wastecarrier.services.resources;
+
+import org.hibernate.validator.constraints.NotEmpty;
+import org.w3c.dom.Document;
+import uk.gov.ea.wastecarrier.services.DatabaseConfiguration;
+import uk.gov.ea.wastecarrier.services.MockConfiguration;
+import uk.gov.ea.wastecarrier.services.core.mocks.WorldpayOrder;
+import uk.gov.ea.wastecarrier.services.dao.MockWorldpayDao;
+import uk.gov.ea.wastecarrier.services.helper.WorldpayHelper;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+import java.net.URI;
+import java.util.logging.Logger;
+
+@Path("/mocks")
+public class MocksResource {
+
+    private final MockWorldpayDao dao;
+    private final WorldpayHelper helper;
+    private final Integer mockDelay;
+
+    private Logger log = Logger.getLogger(MocksResource.class.getName());
+
+    public MocksResource(DatabaseConfiguration configuration, MockConfiguration config) {
+        this.dao = new MockWorldpayDao(configuration);
+        this.helper = new WorldpayHelper(config.worldPayAdminCode, config.servicesDomain, config.macSecret);
+        this.mockDelay = config.delay;
+    }
+
+    @GET
+    @Path("/worldpay/payment-service")
+    public String paymentService(String body) {
+        Document xmlBody = helper.stringToXml(body);
+
+        WorldpayOrder order = helper.convertFromXml(xmlBody);
+        this.dao.insert(order);
+
+        delay();
+
+        return helper.initialResponse(order.merchantCode, order.orderCode, order.worldpayId);
+    }
+
+    @GET
+    @Path("/worldpay/dispatcher")
+    public Response dispatcher(
+            @QueryParam("OrderKey") @NotEmpty String orderKey,
+            @QueryParam("successURL") @NotEmpty String successUrl,
+            @QueryParam("pendingURL") @NotEmpty String pendingURL,
+            @QueryParam("failureURL") @NotEmpty String failureURL,
+            @QueryParam("cancelURL") @NotEmpty String cancelURL,
+            @QueryParam("errorURL") @NotEmpty String errorURL
+    ) {
+
+        String orderCode = this.helper.extractOrderCodeFromKey(orderKey);
+
+        WorldpayOrder order = this.dao.findByOrderCode(orderCode);
+        String redirectUrl = this.helper.orderCompletedRedirectUrl(order, successUrl);
+
+        URI target = UriBuilder.fromUri(redirectUrl).build();
+
+        delay();
+
+        return Response.seeOther(target).build();
+    }
+
+    private void delay() {
+
+        try {
+            Thread.sleep(this.mockDelay);
+        } catch (InterruptedException ex) {
+            log.severe("Error trying to delay mock responses: " + ex);
+        }
+    }
+}

--- a/src/main/resources/mocks/worldpay/initialResponse.xml
+++ b/src/main/resources/mocks/worldpay/initialResponse.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+        "http://dtd.worldpay.com/paymentService_v1.dtd">
+<paymentService version="1.4" merchantCode="MERCHANT_CODE"><reply><orderStatus orderCode="ORDER_CODE"><reference id="WORLDPAY_ID">WORLDPAY_URL?OrderKey=MERCHANT_CODE%5EORDER_CODE</reference></orderStatus></reply></paymentService>

--- a/src/test/java/uk/gov/ea/wastecarrier/services/MockWorldpayDaoTest.java
+++ b/src/test/java/uk/gov/ea/wastecarrier/services/MockWorldpayDaoTest.java
@@ -1,0 +1,72 @@
+package uk.gov.ea.wastecarrier.services;
+
+import org.junit.*;
+import uk.gov.ea.wastecarrier.services.core.mocks.WorldpayOrder;
+import uk.gov.ea.wastecarrier.services.support.MockWorldpayOrderConnectionUtil;
+import uk.gov.ea.wastecarrier.services.support.WorldpayOrderBuilder;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class MockWorldpayDaoTest {
+
+    private static MockWorldpayOrderConnectionUtil connection;
+
+    @BeforeClass
+    public static void setup() {
+        connection = new MockWorldpayOrderConnectionUtil();
+    }
+
+    /**
+     * Deletes any orders we have created during testing
+     */
+    @AfterClass
+    public static void tearDown() {
+        connection.clean();
+    }
+
+    @Test
+    public void checkConnection() {
+        assertTrue("Returns true when credentials are valid", connection.dao.checkConnection());
+    }
+
+    @Test(expected = Exception.class)
+    public void checkConnectionThrowsExceptionWhenConfigInvalid() {
+        connection.invalidCredentialsDao().checkConnection();
+    }
+
+    @Test
+    public void insert() {
+        WorldpayOrder document = new WorldpayOrderBuilder()
+                .build();
+
+        String id = connection.dao.insert(document).id;
+
+        assertTrue("The order is inserted", id != null && !id.isEmpty());
+    }
+
+    @Test
+    public void find() {
+        WorldpayOrder document = new WorldpayOrderBuilder()
+                .build();
+
+        String id = connection.dao.insert(document).id;
+
+        document = connection.dao.find(id);
+
+        assertEquals("The order is found", id, document.id);
+    }
+
+    @Test
+    public void findByOrderCode() {
+        String orderCode = "1234567890";
+
+        WorldpayOrder document = new WorldpayOrderBuilder()
+                .orderCode(orderCode)
+                .build();
+
+        connection.dao.insert(document);
+
+        assertEquals("The order is found", orderCode, connection.dao.findByOrderCode(orderCode).orderCode);
+    }
+}

--- a/src/test/java/uk/gov/ea/wastecarrier/services/WorldpayHelperTest.java
+++ b/src/test/java/uk/gov/ea/wastecarrier/services/WorldpayHelperTest.java
@@ -1,0 +1,95 @@
+package uk.gov.ea.wastecarrier.services;
+
+import org.junit.*;
+import org.w3c.dom.Document;
+import uk.gov.ea.wastecarrier.services.core.mocks.WorldpayOrder;
+import uk.gov.ea.wastecarrier.services.helper.WorldpayHelper;
+import uk.gov.ea.wastecarrier.services.support.FixtureReader;
+import uk.gov.ea.wastecarrier.services.support.WorldpayOrderBuilder;
+
+import java.io.IOException;
+
+import static org.junit.Assert.*;
+
+public class WorldpayHelperTest {
+
+    private static WorldpayHelper helper;
+
+    @BeforeClass
+    public static void setup() {
+        helper = new WorldpayHelper(
+                "ENVIRONMENTAGENCY",
+                "http://localhost:8005",
+                "macKeydaddyyeahfool@7"
+        );
+    }
+
+    @Test
+    public void stringToXml() throws IOException {
+        String xml = FixtureReader.readFile("src/test/resources/fixtures/worldpayInitialRequest.xml");
+        Document result = helper.stringToXml(xml);
+
+        assertNotNull(result);
+        assertEquals("paymentService", result.getDocumentElement().getNodeName());
+    }
+
+    @Test
+    public void initialResponse() {
+        String result = helper.initialResponse("TEST_MERCHANT", "TEST_ORDER", "TEST_ID");
+
+        assertNotNull(result);
+        assertTrue(result.contains("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"));
+        assertTrue(result.contains("TEST_MERCHANT"));
+        assertTrue(result.contains("TEST_ORDER"));
+        assertTrue(result.contains("TEST_ID"));
+    }
+
+    @Test
+    public void convertFromXml() throws IOException {
+        String xml = FixtureReader.readFile("src/test/resources/fixtures/worldpayInitialRequest.xml");
+        Document result = helper.stringToXml(xml);
+
+        WorldpayOrder order = helper.convertFromXml(result);
+        assertEquals("1530087444", order.orderCode);
+        assertEquals((Integer)10500, order.value);
+    }
+
+    @Test
+    public void generateWorldpayId() {
+
+        String id = helper.generateWorldPayId();
+
+        assertTrue("Id generated is 10 chars in length",id.length() == 10);
+        assertTrue("Id generated only contains numbers", id.matches("[0-9]+"));
+    }
+
+    @Test
+    public void extractOrderCodeFromKey() {
+        String result = helper.extractOrderCodeFromKey("MERCHANTCODE^1530092035");
+        assertNotNull("I get a response", result);
+        assertEquals("I get just the order code", "1530092035", result);
+    }
+
+    @Test
+    public void orderCompletedRedirectUrl() {
+        WorldpayOrder document = new WorldpayOrderBuilder()
+                .orderCode("1530105721")
+                .merchantCode("WCRSERVICE")
+                .value(10500)
+                .build();
+
+        String result = helper.orderCompletedRedirectUrl(document, "http://localhost:3002");
+        assertEquals("http://localhost:3002?orderKey=ENVIRONMENTAGENCY%5EWCRSERVICE%5E1530105721&paymentStatus=AUTHORISED&paymentAmount=10500&paymentCurrency=GBP&mac=361bb202cd425177602db0f15c84f365&source=WP", result);
+    }
+
+    @Test
+    public void generateMac() {
+        WorldpayOrder document = new WorldpayOrderBuilder()
+                .orderCode("1530105721")
+                .merchantCode("WCRSERVICE")
+                .value(10500)
+                .build();
+
+        assertEquals("361bb202cd425177602db0f15c84f365", helper.generateMac(document));
+    }
+}

--- a/src/test/java/uk/gov/ea/wastecarrier/services/support/FixtureReader.java
+++ b/src/test/java/uk/gov/ea/wastecarrier/services/support/FixtureReader.java
@@ -1,0 +1,15 @@
+package uk.gov.ea.wastecarrier.services.support;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+public class FixtureReader {
+
+    public static String readFile(String path) throws IOException {
+
+        byte[] encoded = Files.readAllBytes(Paths.get(path));
+        return new String(encoded, Charset.defaultCharset());
+    }
+}

--- a/src/test/java/uk/gov/ea/wastecarrier/services/support/MockWorldpayOrderConnectionUtil.java
+++ b/src/test/java/uk/gov/ea/wastecarrier/services/support/MockWorldpayOrderConnectionUtil.java
@@ -1,0 +1,42 @@
+package uk.gov.ea.wastecarrier.services.support;
+
+import uk.gov.ea.wastecarrier.services.DatabaseConfiguration;
+import uk.gov.ea.wastecarrier.services.dao.MockWorldpayDao;
+import uk.gov.ea.wastecarrier.services.helper.DatabaseHelper;
+import uk.gov.ea.wastecarrier.services.helper.SearchHelper;
+
+public class MockWorldpayOrderConnectionUtil {
+
+    public DatabaseHelper databaseHelper;
+    public MockWorldpayDao dao;
+    public SearchHelper searchHelper;
+
+    public MockWorldpayOrderConnectionUtil() {
+        String url  = System.getenv("WCRS_TEST_REGSDB_URL1");
+        String name = System.getenv("WCRS_TEST_REGSDB_NAME");
+        String username = System.getenv("WCRS_TEST_REGSDB_USERNAME");
+        String password = System.getenv("WCRS_TEST_REGSDB_PASSWORD");
+        int timeout = Integer.valueOf(System.getenv("WCRS_TEST_REGSDB_SERVER_SEL_TIMEOUT"));
+
+        DatabaseConfiguration config = new DatabaseConfiguration(url, name, username, password, timeout);
+
+        databaseHelper = new DatabaseHelper(config);
+        dao = new MockWorldpayDao(config);
+        searchHelper = new SearchHelper(databaseHelper, dao);
+    }
+
+    public void clean() {
+        this.dao.getCollection().drop();
+    }
+
+    public MockWorldpayDao invalidCredentialsDao() {
+        DatabaseConfiguration invalidConfig = new DatabaseConfiguration(
+                this.databaseHelper.configuration().getUrl(),
+                this.databaseHelper.configuration().getName(),
+                this.databaseHelper.configuration().getUsername(),
+                "Bl0wMeDownWithAFeather",
+                this.databaseHelper.configuration().getServerSelectionTimeout()
+        );
+        return new MockWorldpayDao(invalidConfig);
+    }
+}

--- a/src/test/java/uk/gov/ea/wastecarrier/services/support/RegistrationBuilder.java
+++ b/src/test/java/uk/gov/ea/wastecarrier/services/support/RegistrationBuilder.java
@@ -378,7 +378,7 @@ public class RegistrationBuilder {
         order.setOrderCode(order.getOrderId());
 
         order.setPaymentMethod(Order.PaymentMethod.ONLINE);
-        order.setMerchantId("EASERRSIMECOM");
+        order.setMerchantId("WCRSERVICE");
         order.setCurrency("GBP");
         order.setDateCreated(this.orderCreatedDate);
         order.setDateLastUpdated(this.orderUpdatedDate);

--- a/src/test/java/uk/gov/ea/wastecarrier/services/support/WorldpayOrderBuilder.java
+++ b/src/test/java/uk/gov/ea/wastecarrier/services/support/WorldpayOrderBuilder.java
@@ -1,0 +1,108 @@
+package uk.gov.ea.wastecarrier.services.support;
+
+import uk.gov.ea.wastecarrier.services.core.mocks.WorldpayOrder;
+import uk.gov.ea.wastecarrier.services.helper.WorldpayHelper;
+
+import java.util.Date;
+
+/**
+ * A class which implements the builder pattern for generating test
+ * entities. Java does not have default parameters but instead utilises
+ * method overloading to achieve the same effect. To make calling code more
+ * explicit we implement the builder pattern e.g.
+ *
+ * WorldpayOrder order1 = new WorldpayOrderBuilder()
+ *                          .build();
+ * WorldpayOrder order2 = new WorldpayOrderBuilder()
+ *                          .orderCode("1234567")
+ *                          .build();
+ * WorldpayOrder order3 = new WorldpayOrderBuilder()
+ *                          .orderCode("7654321")
+ *                          .value(15400)
+ *                          .build();
+ */
+public class WorldpayOrderBuilder {
+
+    private String worldpayId;
+    private String merchantCode = "EAWASTECARRIERS";
+    private String orderCode;
+    private String description = "Your Waste Carrier Registration CBDU999";
+    private String currencyCode = "GBP";
+    private Integer value = 15400;
+    private String exponent = "2";
+    private String orderContent = "Waste Carrier Registration registration: CBDU999 for Wittertainment Ltd";
+    private String shopperEmailAddress = "jason.isaacs@example.com";
+
+    private final WorldpayHelper helper = new WorldpayHelper("","", "");
+
+    public WorldpayOrderBuilder worldpayId(String worldpayId) {
+        this.worldpayId = worldpayId;
+        return this;
+    }
+
+    public WorldpayOrderBuilder merchantCode(String merchantCode) {
+        this.merchantCode = merchantCode;
+        return this;
+    }
+
+    public WorldpayOrderBuilder orderCode(String orderCode) {
+        this.orderCode = orderCode;
+        return this;
+    }
+
+    public WorldpayOrderBuilder description(String description) {
+        this.description = description;
+        return this;
+    }
+
+    public WorldpayOrderBuilder currencyCode(String currencyCode) {
+        this.currencyCode = currencyCode;
+        return this;
+    }
+
+    public WorldpayOrderBuilder value(Integer value) {
+        this.value = value;
+        return this;
+    }
+
+    public WorldpayOrderBuilder exponent(String exponent) {
+        this.exponent = exponent;
+        return this;
+    }
+
+    public WorldpayOrderBuilder orderContent(String orderContent) {
+        this.orderContent = orderContent;
+        return this;
+    }
+
+    public WorldpayOrderBuilder shopperEmailAddress(String shopperEmailAddress) {
+        this.shopperEmailAddress = shopperEmailAddress;
+        return this;
+    }
+
+    public WorldpayOrder build() {
+
+        WorldpayOrder order = new WorldpayOrder();
+
+        order.worldpayId = helper.generateWorldPayId();
+        order.merchantCode = this.merchantCode;
+        order.orderCode = generateOrderCode();
+        order.description = this.description;
+        order.currencyCode = this.currencyCode;
+        order.value = this.value;
+        order.exponent = this.exponent;
+        order.orderContent = this.orderContent;
+        order.shopperEmailAddress = this.shopperEmailAddress;
+
+        return order;
+    }
+
+    private String generateOrderCode() {
+        if (this.orderCode != null && !this.orderCode.isEmpty()) return this.orderCode;
+
+        String timeInMilliseconds = String.valueOf(new Date().getTime());
+
+        return timeInMilliseconds.substring(0, Math.min(timeInMilliseconds.length(), 10));
+    }
+
+}

--- a/src/test/resources/fixtures/worldpayInitialRequest.xml
+++ b/src/test/resources/fixtures/worldpayInitialRequest.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<!DOCTYPE paymentService PUBLIC "-//WorldPay/DTD WorldPay PaymentService v1/EN" "http://dtd.worldpay.com/paymentService_v1.dtd">
+<paymentService version="1.4" merchantCode="WCRSERVICE">
+    <submit>
+        <order orderCode="1530087444">
+            <description>Your Waste Carrier Registration CBDU28</description>
+            <amount currencyCode="GBP" value="10500" exponent="2"/>
+            <orderContent>Waste Carrier Registration renewal: CBDU28 for Sole Trader Seed</orderContent>
+            <paymentMethodMask>
+                <include code="VISA-SSL"/>
+                <include code="MAESTRO-SSL"/>
+                <include code="ECMC-SSL"/>
+            </paymentMethodMask>
+            <shopper>
+                <shopperEmailAddress>user@waste-exemplar.gov.uk</shopperEmailAddress>
+            </shopper>
+            <billingAddress>
+                <address>
+                    <firstName>Test</firstName>
+                    <lastName>User</lastName>
+                    <address1> NATURAL ENGLAND</address1>
+                    <address2>HORIZON HOUSE</address2>
+                    <postalCode>BS1 5AH</postalCode>
+                    <city>BRISTOL</city>
+                    <countryCode>GB</countryCode>
+                </address>
+            </billingAddress>
+        </order>
+    </submit>
+</paymentService>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-365

These changes add the ability for the waste-carriers-service to 'mock' worldpay.

In cases where we need to carry out performance testing we don't want to hit the actual services, for example OS Places for address lookup and Worldpay for payments.

We could have built a separate world-pay-mock-app but then that would mean deploying an extra app just for when we need to do performance testing.

By building it into the service, we simply need to change the env var which holds the url for Worldpay to point to our local instance, and we are able to begin mocking Worldpay.