### PR TITLE
Add ability to mock companies house to services

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,26 @@ Hence the command to build above includes the option to skip tests. Instead we a
 ./mvnw test
 ```
 
+## Mocks
+
+When running performance tests we need the ability to mock external services so as not to get in trouble by putting them under heavy load. To support this in the simplest way, we have built mocking functionality into this project.
+
+Note, where example endpoints are given you should amend them to match your own environment setup.
+
+### Companies House
+
+The service has the ability to mock the [Companies House API](https://api.companieshouse.gov.uk/company/). It simply has recorded the JSON responses for a number of companies, provides a resource that matches the real endpoint. Simply point the user facing app to <http://localhost:8003/mocks/company/> within its config and if the company number provided matches one of those previously recorded it will return a response.
+
+If no value is passed through (null) then `{}` is returned. Else if a number is sent that does not match a pre-recorded response the service will return the same 'not found' JSON that Companies House does.
+
+### Worldpay
+
+The service has the ability to mock [Worldpay](http://support.worldpay.com/support/kb/gg/corporate-gateway-guide/content/home.htm). It doesn't present a UI for users to fill in payment details like the real Worldpay, but it does handle the same [XML interactions](https://github.com/DEFRA/waste-carriers-renewals/wiki/Making-a-payment-with-WorldPay).
+
+So it can receive the initial request at <http://localhost:8003/mocks/worldpay/payment-service>, will save the order details to MongoDb and then return the correct redirect url to the client app. That url points back to this service at <http://localhost:8003/mocks/worldpay/dispatcher> which when called will return a valid success response for the specified order.
+
+For this to work the Worldpay environment variables the service is reading from must match those being used by the client app else the client will reject the success response provided by the service.
+
 ## Contributing to this project
 
 If you have an idea you'd like to contribute please log an issue.

--- a/src/main/java/uk/gov/ea/wastecarrier/services/helper/mocks/CompaniesHouseHelper.java
+++ b/src/main/java/uk/gov/ea/wastecarrier/services/helper/mocks/CompaniesHouseHelper.java
@@ -1,0 +1,34 @@
+package uk.gov.ea.wastecarrier.services.helper.mocks;
+
+import uk.gov.ea.wastecarrier.services.helper.ResourceHelper;
+
+public class CompaniesHouseHelper {
+
+    private static final String CH_RESOURCE_PATH = "mocks/companies";
+    private static final String EMPTY_RESPONSE = "{}";
+
+    private final ResourceHelper resourceHelper;
+
+    public CompaniesHouseHelper() {
+        this.resourceHelper = new ResourceHelper();
+    }
+
+    public String response(String companyNumber) {
+
+        // If no company number is provided Companies house just sends an empty
+        // json response
+        if (companyNumber == null || companyNumber.isEmpty()) return EMPTY_RESPONSE;
+
+        String filename = companyNumber.trim().toUpperCase() + ".json";
+
+        String result = this.resourceHelper.openResourceFile(CH_RESOURCE_PATH, filename);
+
+        if (result == null || result.isEmpty()) return notFound();
+
+        return result;
+    }
+
+    private String notFound() {
+        return this.resourceHelper.openResourceFile(CH_RESOURCE_PATH, "not_found.json");
+    }
+}

--- a/src/main/java/uk/gov/ea/wastecarrier/services/helper/mocks/WorldpayHelper.java
+++ b/src/main/java/uk/gov/ea/wastecarrier/services/helper/mocks/WorldpayHelper.java
@@ -1,9 +1,10 @@
-package uk.gov.ea.wastecarrier.services.helper;
+package uk.gov.ea.wastecarrier.services.helper.mocks;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.xml.sax.InputSource;
 import uk.gov.ea.wastecarrier.services.core.mocks.WorldpayOrder;
+import uk.gov.ea.wastecarrier.services.helper.ResourceHelper;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;

--- a/src/main/resources/mocks/companies/00445790.json
+++ b/src/main/resources/mocks/companies/00445790.json
@@ -1,0 +1,66 @@
+{
+  "accounts": {
+    "overdue": false,
+    "last_accounts": {
+      "type": "group",
+      "period_end_on": "2017-02-25",
+      "made_up_to": "2017-02-25",
+      "period_start_on": "2016-02-28"
+    },
+    "next_accounts": {
+      "period_end_on": "2018-02-26",
+      "due_on": "2018-08-26",
+      "period_start_on": "2017-02-26",
+      "overdue": false
+    },
+    "accounting_reference_date": {
+      "month": "02",
+      "day": "26"
+    },
+    "next_due": "2018-08-26",
+    "next_made_up_to": "2018-02-26"
+  },
+  "company_name": "TESCO PLC",
+  "undeliverable_registered_office_address": false,
+  "type": "plc",
+  "sic_codes": [
+    "47110"
+  ],
+  "registered_office_address": {
+    "country": "United Kingdom",
+    "address_line_2": "Kestrel Way",
+    "locality": "Welwyn Garden City",
+    "address_line_1": "Tesco House, Shire Park",
+    "postal_code": "AL7 1GA"
+  },
+  "jurisdiction": "england-wales",
+  "company_number": "00445790",
+  "has_been_liquidated": false,
+  "date_of_creation": "1947-11-27",
+  "last_full_members_list_date": "2013-06-07",
+  "company_status": "active",
+  "etag": "ca5769f09c104a0cd5997dcf7c1912aa1f3fe7b5",
+  "has_charges": true,
+  "has_insolvency_history": false,
+  "previous_company_names": [
+    {
+      "effective_from": "1947-11-27",
+      "ceased_on": "1983-08-25",
+      "name": "TESCO STORES (HOLDINGS) PUBLIC LIMITED COMPANY"
+    }
+  ],
+  "confirmation_statement": {
+    "last_made_up_to": "2017-06-07",
+    "next_made_up_to": "2018-06-07",
+    "next_due": "2018-06-21",
+    "overdue": false
+  },
+  "links": {
+    "self": "/company/00445790",
+    "filing_history": "/company/00445790/filing-history",
+    "officers": "/company/00445790/officers",
+    "charges": "/company/00445790/charges"
+  },
+  "registered_office_is_in_dispute": false,
+  "can_file": true
+}

--- a/src/main/resources/mocks/companies/01649776.json
+++ b/src/main/resources/mocks/companies/01649776.json
@@ -1,0 +1,68 @@
+{
+  "company_name": "CACI LIMITED",
+  "date_of_creation": "1982-07-09",
+  "undeliverable_registered_office_address": false,
+  "type": "ltd",
+  "company_number": "01649776",
+  "jurisdiction": "england-wales",
+  "last_full_members_list_date": "2015-10-11",
+  "has_been_liquidated": false,
+  "sic_codes": [
+    "58290",
+    "62020",
+    "63110",
+    "73200"
+  ],
+  "registered_office_address": {
+    "address_line_2": "Avonmore Road",
+    "locality": "London",
+    "postal_code": "W14 8TS",
+    "address_line_1": "Caci House Kensington Village"
+  },
+  "accounts": {
+    "next_accounts": {
+      "due_on": "2019-03-31",
+      "period_end_on": "2018-06-30",
+      "overdue": false,
+      "period_start_on": "2017-07-01"
+    },
+    "overdue": false,
+    "next_due": "2019-03-31",
+    "next_made_up_to": "2018-06-30",
+    "last_accounts": {
+      "type": "full",
+      "period_start_on": "2016-07-01",
+      "made_up_to": "2017-06-30",
+      "period_end_on": "2017-06-30"
+    },
+    "accounting_reference_date": {
+      "month": "06",
+      "day": "30"
+    }
+  },
+  "has_insolvency_history": false,
+  "etag": "c417e3b8d136322bcc515d71e0c720dbc0973432",
+  "company_status": "active",
+  "previous_company_names": [
+    {
+      "effective_from": "1982-07-09",
+      "ceased_on": "1983-01-21",
+      "name": "SECUREFAME LIMITED"
+    }
+  ],
+  "has_charges": false,
+  "confirmation_statement": {
+    "next_made_up_to": "2018-10-11",
+    "overdue": false,
+    "next_due": "2018-10-25",
+    "last_made_up_to": "2017-10-11"
+  },
+  "links": {
+    "self": "/company/01649776",
+    "filing_history": "/company/01649776/filing-history",
+    "officers": "/company/01649776/officers",
+    "persons_with_significant_control_statements": "/company/01649776/persons-with-significant-control-statements"
+  },
+  "registered_office_is_in_dispute": false,
+  "can_file": true
+}

--- a/src/main/resources/mocks/companies/02050399.json
+++ b/src/main/resources/mocks/companies/02050399.json
@@ -1,0 +1,75 @@
+{
+  "company_number": "02050399",
+  "accounts": {
+    "accounting_reference_date": {
+      "month": "03",
+      "day": "31"
+    },
+    "next_due": "2018-12-31",
+    "next_made_up_to": "2018-03-31",
+    "overdue": false,
+    "last_accounts": {
+      "period_start_on": "2016-04-01",
+      "made_up_to": "2017-03-31",
+      "type": "micro-entity",
+      "period_end_on": "2017-03-31"
+    },
+    "next_accounts": {
+      "period_end_on": "2018-03-31",
+      "overdue": false,
+      "period_start_on": "2017-04-01",
+      "due_on": "2018-12-31"
+    }
+  },
+  "jurisdiction": "england-wales",
+  "registered_office_address": {
+    "region": "Mid Glamorgan",
+    "locality": "Caerphilly",
+    "postal_code": "CF83 1BR",
+    "address_line_1": "15 Lon Uchaf Lon Uchaf"
+  },
+  "last_full_members_list_date": "2015-12-31",
+  "date_of_creation": "1986-08-28",
+  "type": "ltd",
+  "has_been_liquidated": false,
+  "company_name": "ZENITH PRINT (UK) LIMITED",
+  "sic_codes": [
+    "70100"
+  ],
+  "undeliverable_registered_office_address": false,
+  "has_insolvency_history": false,
+  "etag": "9c6b544fbd0427cdfbb53e0870ca8fa32c084470",
+  "company_status": "active",
+  "has_charges": true,
+  "previous_company_names": [
+    {
+      "ceased_on": "1996-03-22",
+      "effective_from": "1993-04-22",
+      "name": "ZENITH TREFOREST PRESS LIMITED"
+    },
+    {
+      "name": "ZENITH COLOUR PRINTING LIMITED",
+      "ceased_on": "1993-04-22",
+      "effective_from": "1986-11-14"
+    },
+    {
+      "effective_from": "1986-08-28",
+      "ceased_on": "1986-11-14",
+      "name": "CHANCETACKLE LIMITED"
+    }
+  ],
+  "confirmation_statement": {
+    "last_made_up_to": "2017-12-31",
+    "next_made_up_to": "2018-12-31",
+    "overdue": false,
+    "next_due": "2019-01-14"
+  },
+  "links": {
+    "self": "/company/02050399",
+    "filing_history": "/company/02050399/filing-history",
+    "officers": "/company/02050399/officers",
+    "charges": "/company/02050399/charges"
+  },
+  "registered_office_is_in_dispute": false,
+  "can_file": true
+}

--- a/src/main/resources/mocks/companies/04270505.json
+++ b/src/main/resources/mocks/companies/04270505.json
@@ -1,0 +1,74 @@
+{
+  "registered_office_address": {
+    "postal_code": "NE1 3DX",
+    "locality": "Newcastle-Upon-Tyne",
+    "address_line_1": "Quayside House",
+    "address_line_2": "110 Quayside"
+  },
+  "has_been_liquidated": false,
+  "accounts": {
+    "overdue": false,
+    "next_accounts": {
+      "period_start_on": "2017-04-01",
+      "overdue": false,
+      "period_end_on": "2018-03-31",
+      "due_on": "2018-12-31"
+    },
+    "last_accounts": {
+      "made_up_to": "2017-03-31",
+      "type": "full",
+      "period_start_on": "2016-04-01",
+      "period_end_on": "2017-03-31"
+    },
+    "accounting_reference_date": {
+      "month": "03",
+      "day": "31"
+    },
+    "next_due": "2018-12-31",
+    "next_made_up_to": "2018-03-31"
+  },
+  "jurisdiction": "england-wales",
+  "company_name": "TSF RETAIL SOLUTIONS LIMITED",
+  "type": "ltd",
+  "last_full_members_list_date": "2015-08-15",
+  "sic_codes": [
+    "43320",
+    "43390",
+    "43999"
+  ],
+  "date_of_creation": "2001-08-15",
+  "company_number": "04270505",
+  "undeliverable_registered_office_address": false,
+  "has_insolvency_history": true,
+  "etag": "10e0fbecf509eb0f9ded760a89ced81a13991fe2",
+  "company_status": "administration",
+  "has_charges": true,
+  "previous_company_names": [
+    {
+      "ceased_on": "2006-06-01",
+      "name": "MOMS LIMITED",
+      "effective_from": "2001-11-01"
+    },
+    {
+      "effective_from": "2001-08-15",
+      "name": "BLAZECLEAN LIMITED",
+      "ceased_on": "2001-11-01"
+    }
+  ],
+  "confirmation_statement": {
+    "overdue": false,
+    "next_made_up_to": "2018-08-15",
+    "last_made_up_to": "2017-08-15",
+    "next_due": "2018-08-29"
+  },
+  "links": {
+    "self": "/company/04270505",
+    "filing_history": "/company/04270505/filing-history",
+    "officers": "/company/04270505/officers",
+    "charges": "/company/04270505/charges",
+    "insolvency": "/company/04270505/insolvency",
+    "persons_with_significant_control": "/company/04270505/persons-with-significant-control"
+  },
+  "registered_office_is_in_dispute": false,
+  "can_file": true
+}

--- a/src/main/resources/mocks/companies/05868270.json
+++ b/src/main/resources/mocks/companies/05868270.json
@@ -1,0 +1,44 @@
+{
+  "has_been_liquidated": true,
+  "last_full_members_list_date": "2013-07-06",
+  "date_of_creation": "2006-07-06",
+  "type": "ltd",
+  "sic_codes": [
+    "62012",
+    "63110",
+    "63120"
+  ],
+  "jurisdiction": "england-wales",
+  "company_name": "BEEF LTD",
+  "registered_office_address": {
+    "address_line_2": "Bath Road",
+    "locality": "Bristol",
+    "postal_code": "BS4 3EH",
+    "address_line_1": "Unit 1.10 The Paintworks"
+  },
+  "company_number": "05868270",
+  "undeliverable_registered_office_address": false,
+  "accounts": {
+    "accounting_reference_date": {
+      "month": "08",
+      "day": "31"
+    },
+    "last_accounts": {
+      "type": "total-exemption-small",
+      "made_up_to": "2012-08-31"
+    }
+  },
+  "has_insolvency_history": true,
+  "etag": "d40ffbea6e7243a46b5626710fdfcb29c515cb62",
+  "company_status": "dissolved",
+  "has_charges": false,
+  "links": {
+    "self": "/company/05868270",
+    "filing_history": "/company/05868270/filing-history",
+    "officers": "/company/05868270/officers",
+    "insolvency": "/company/05868270/insolvency"
+  },
+  "registered_office_is_in_dispute": false,
+  "date_of_cessation": "2016-12-13",
+  "can_file": false
+}

--- a/src/main/resources/mocks/companies/10761329.json
+++ b/src/main/resources/mocks/companies/10761329.json
@@ -1,0 +1,53 @@
+{
+  "registered_office_is_in_dispute": false,
+  "has_charges": false,
+  "undeliverable_registered_office_address": false,
+  "type": "ltd",
+  "company_status": "active",
+  "links": {
+    "self": "/company/10761329",
+    "persons_with_significant_control": "/company/10761329/persons-with-significant-control",
+    "filing_history": "/company/10761329/filing-history",
+    "officers": "/company/10761329/officers"
+  },
+  "has_insolvency_history": false,
+  "company_number": "10761329",
+  "company_name": "WASTE AWAY SERVICES LTD",
+  "confirmation_statement": {
+    "next_made_up_to": "2019-05-08",
+    "next_due": "2019-05-22",
+    "last_made_up_to": "2018-05-08",
+    "overdue": false
+  },
+  "accounts": {
+    "next_due": "2019-02-09",
+    "last_accounts": {
+      "type": "null"
+    },
+    "next_made_up_to": "2018-05-31",
+    "next_accounts": {
+      "overdue": false,
+      "due_on": "2019-02-09",
+      "period_start_on": "2017-05-09",
+      "period_end_on": "2018-05-31"
+    },
+    "overdue": false,
+    "accounting_reference_date": {
+      "day": "31",
+      "month": "05"
+    }
+  },
+  "sic_codes": [
+    "96090"
+  ],
+  "registered_office_address": {
+    "country": "United Kingdom",
+    "postal_code": "EN11 0AE",
+    "address_line_1": "72 Old Essex Road",
+    "locality": "Hoddesdon"
+  },
+  "etag": "bc6a4de9856f247606d8c4311d08e3d45f838145",
+  "jurisdiction": "england-wales",
+  "date_of_creation": "2017-05-09",
+  "can_file": true
+}

--- a/src/main/resources/mocks/companies/10926928.json
+++ b/src/main/resources/mocks/companies/10926928.json
@@ -1,0 +1,51 @@
+{
+  "sic_codes": [
+    "49410"
+  ],
+  "has_charges": false,
+  "links": {
+    "self": "/company/10926928",
+    "filing_history": "/company/10926928/filing-history",
+    "officers": "/company/10926928/officers"
+  },
+  "has_insolvency_history": false,
+  "undeliverable_registered_office_address": false,
+  "confirmation_statement": {
+    "next_due": "2018-09-04",
+    "overdue": false,
+    "next_made_up_to": "2018-08-21"
+  },
+  "company_number": "10926928",
+  "jurisdiction": "england-wales",
+  "date_of_creation": "2017-08-22",
+  "registered_office_is_in_dispute": false,
+  "type": "ltd",
+  "registered_office_address": {
+    "address_line_1": "128a Bridge Road",
+    "postal_code": "RM17 6DA",
+    "locality": "Grays",
+    "country": "United Kingdom"
+  },
+  "company_status": "active",
+  "company_name": "VIOLA LTD",
+  "accounts": {
+    "next_due": "2019-05-22",
+    "overdue": false,
+    "accounting_reference_date": {
+      "day": "31",
+      "month": "08"
+    },
+    "last_accounts": {
+      "type": "null"
+    },
+    "next_accounts": {
+      "period_start_on": "2017-08-22",
+      "period_end_on": "2018-08-31",
+      "overdue": false,
+      "due_on": "2019-05-22"
+    },
+    "next_made_up_to": "2018-08-31"
+  },
+  "etag": "2591791b76d074cd21cc5721d3984328bcf8d4e6",
+  "can_file": true
+}

--- a/src/main/resources/mocks/companies/IP031977.json
+++ b/src/main/resources/mocks/companies/IP031977.json
@@ -1,0 +1,27 @@
+{
+  "company_name": "ENERGISE STUR VALLEY INDUSTRIAL AND PROVIDENT SOCIETY LIMITED",
+  "has_been_liquidated": false,
+  "undeliverable_registered_office_address": false,
+  "type": "industrial-and-provident-society",
+  "company_number": "IP031977",
+  "jurisdiction": "england-wales",
+  "etag": "9c5773301b80b237e084f71a5766c14c1cbc77eb",
+  "company_status": "active",
+  "has_charges": false,
+  "has_insolvency_history": false,
+  "accounts": {
+    "last_accounts": {
+      "type": "null"
+    },
+    "accounting_reference_date": {
+      "day": "99",
+      "month": "99"
+    }
+  },
+  "links": {
+    "self": "/company/IP031977"
+  },
+  "partial_data_available": "full-data-available-from-financial-conduct-authority-mutuals-public-register",
+  "registered_office_address": {},
+  "can_file": false
+}

--- a/src/main/resources/mocks/companies/IP27406R.json
+++ b/src/main/resources/mocks/companies/IP27406R.json
@@ -1,0 +1,32 @@
+{
+  "company_name": "UPPER WENSLEYDALE INDUSTRIAL AND PROVIDENT SOCIETY LIMITED",
+  "type": "industrial-and-provident-society",
+  "company_number": "IP27406R",
+  "jurisdiction": "england-wales",
+  "has_been_liquidated": false,
+  "undeliverable_registered_office_address": false,
+  "etag": "da4c1491f5f591ef41c24bba57bb0806ea2c4417",
+  "company_status": "active",
+  "has_insolvency_history": false,
+  "has_charges": false,
+  "registered_office_address": {
+    "address_line_1": "",
+    "locality": "",
+    "postal_code": "",
+    "address_line_2": ""
+  },
+  "accounts": {
+    "accounting_reference_date": {
+      "month": "99",
+      "day": "99"
+    },
+    "last_accounts": {
+      "type": "null"
+    }
+  },
+  "links": {
+    "self": "/company/IP27406R"
+  },
+  "partial_data_available": "full-data-available-from-financial-conduct-authority-mutuals-public-register",
+  "can_file": false
+}

--- a/src/main/resources/mocks/companies/NC000059.json
+++ b/src/main/resources/mocks/companies/NC000059.json
@@ -1,0 +1,39 @@
+{
+  "accounts": {
+    "accounting_reference_date": {
+      "day": "31",
+      "month": "12"
+    },
+    "last_accounts": {
+      "period_end_on": "2016-12-31",
+      "type": "micro-entity",
+      "made_up_to": "2016-12-31"
+    }
+  },
+  "company_name": "PROTEC (NI) LLP",
+  "has_been_liquidated": false,
+  "undeliverable_registered_office_address": false,
+  "registered_office_address": {
+    "region": "Co Antrim",
+    "address_line_2": "Hyde Park Industrial Estate",
+    "address_line_1": "6 Trench Road",
+    "locality": "Newtownabbey"
+  },
+  "company_number": "NC000059",
+  "date_of_creation": "2005-10-31",
+  "type": "llp",
+  "jurisdiction": "northern-ireland",
+  "has_insolvency_history": false,
+  "etag": "6e42ee2ede64d1513b624789390e334319b69480",
+  "company_status": "dissolved",
+  "has_charges": false,
+  "links": {
+    "self": "/company/NC000059",
+    "filing_history": "/company/NC000059/filing-history",
+    "officers": "/company/NC000059/officers",
+    "persons_with_significant_control": "/company/NC000059/persons-with-significant-control"
+  },
+  "registered_office_is_in_dispute": false,
+  "date_of_cessation": "2018-04-17",
+  "can_file": false
+}

--- a/src/main/resources/mocks/companies/NI063992.json
+++ b/src/main/resources/mocks/companies/NI063992.json
@@ -1,0 +1,68 @@
+{
+  "has_been_liquidated": false,
+  "last_full_members_list_date": "2016-06-01",
+  "jurisdiction": "northern-ireland",
+  "company_name": "AMEY ROADS NI FINANCIAL PLC",
+  "sic_codes": [
+    "82990"
+  ],
+  "status": "active",
+  "registered_office_address": {
+    "address_line_2": "Murray Street",
+    "postal_code": "BT1 6DN",
+    "locality": "Belfast",
+    "address_line_1": "Murray House",
+    "care_of": "CARSON MCDOWELL LLP"
+  },
+  "type": "plc",
+  "company_number": "NI063992",
+  "accounts": {
+    "next_due": "2018-09-30",
+    "accounting_reference_date": {
+      "month": "03",
+      "day": "31"
+    },
+    "overdue": false,
+    "last_accounts": {
+      "period_start_on": "2016-04-01",
+      "period_end_on": "2017-03-31",
+      "type": "full",
+      "made_up_to": "2017-03-31"
+    },
+    "next_made_up_to": "2018-03-31",
+    "next_accounts": {
+      "due_on": "2018-09-30",
+      "overdue": false,
+      "period_end_on": "2018-03-31",
+      "period_start_on": "2017-04-01"
+    }
+  },
+  "date_of_creation": "2007-04-04",
+  "undeliverable_registered_office_address": false,
+  "has_insolvency_history": false,
+  "etag": "230d735185718c66d650087a19373ce4bb06f8d2",
+  "company_status": "active",
+  "has_charges": true,
+  "previous_company_names": [
+    {
+      "name": "AMEY LAGAN ROADS FINANCIAL PLC",
+      "effective_from": "2007-04-04",
+      "ceased_on": "2014-12-12"
+    }
+  ],
+  "confirmation_statement": {
+    "next_made_up_to": "2019-06-01",
+    "last_made_up_to": "2018-06-01",
+    "next_due": "2019-06-15",
+    "overdue": false
+  },
+  "links": {
+    "self": "/company/NI063992",
+    "filing_history": "/company/NI063992/filing-history",
+    "officers": "/company/NI063992/officers",
+    "charges": "/company/NI063992/charges",
+    "persons_with_significant_control": "/company/NI063992/persons-with-significant-control"
+  },
+  "registered_office_is_in_dispute": false,
+  "can_file": true
+}

--- a/src/main/resources/mocks/companies/OC379171.json
+++ b/src/main/resources/mocks/companies/OC379171.json
@@ -1,0 +1,55 @@
+{
+  "date_of_creation": "2012-10-10",
+  "type": "llp",
+  "jurisdiction": "england-wales",
+  "company_name": "OC LAW LLP",
+  "registered_office_address": {
+    "region": "South Yorkshire",
+    "locality": "Sheffield",
+    "postal_code": "S9 1TP",
+    "address_line_2": "250 Shepcote Lane",
+    "address_line_1": "Pm House"
+  },
+  "company_number": "OC379171",
+  "has_been_liquidated": false,
+  "status": "active",
+  "accounts": {
+    "next_accounts": {
+      "period_end_on": "2018-03-31",
+      "due_on": "2018-12-31",
+      "period_start_on": "2017-04-01",
+      "overdue": false
+    },
+    "last_accounts": {
+      "period_start_on": "2016-04-01",
+      "made_up_to": "2017-03-31",
+      "period_end_on": "2017-03-31"
+    },
+    "next_made_up_to": "2018-03-31",
+    "overdue": false,
+    "next_due": "2018-12-31",
+    "accounting_reference_date": {
+      "month": "03",
+      "day": "31"
+    }
+  },
+  "undeliverable_registered_office_address": false,
+  "has_insolvency_history": false,
+  "etag": "0b34e1fe2a1d437fb652baffa96974f9f08a874c",
+  "company_status": "active",
+  "has_charges": false,
+  "confirmation_statement": {
+    "next_due": "2018-10-24",
+    "last_made_up_to": "2017-10-10",
+    "overdue": false,
+    "next_made_up_to": "2018-10-10"
+  },
+  "links": {
+    "self": "/company/OC379171",
+    "filing_history": "/company/OC379171/filing-history",
+    "officers": "/company/OC379171/officers",
+    "persons_with_significant_control": "/company/OC379171/persons-with-significant-control"
+  },
+  "registered_office_is_in_dispute": false,
+  "can_file": false
+}

--- a/src/main/resources/mocks/companies/SC028747.json
+++ b/src/main/resources/mocks/companies/SC028747.json
@@ -1,0 +1,58 @@
+{
+  "type": "ltd",
+  "registered_office_address": {
+    "postal_code": "G71 7HH",
+    "address_line_1": "34 Old Mill Road",
+    "address_line_2": "Uddingston"
+  },
+  "company_number": "SC028747",
+  "company_name": "THOMAS TUNNOCK LIMITED",
+  "undeliverable_registered_office_address": false,
+  "accounts": {
+    "overdue": false,
+    "accounting_reference_date": {
+      "month": "02",
+      "day": "28"
+    },
+    "next_accounts": {
+      "overdue": false,
+      "due_on": "2018-11-30",
+      "period_end_on": "2018-02-28",
+      "period_start_on": "2017-02-26"
+    },
+    "next_due": "2018-11-30",
+    "next_made_up_to": "2018-02-28",
+    "last_accounts": {
+      "made_up_to": "2017-02-25",
+      "type": "full",
+      "period_start_on": "2016-03-01",
+      "period_end_on": "2017-02-25"
+    }
+  },
+  "jurisdiction": "scotland",
+  "sic_codes": [
+    "32990"
+  ],
+  "last_full_members_list_date": "2016-05-09",
+  "has_been_liquidated": false,
+  "status": "active",
+  "date_of_creation": "1952-02-16",
+  "has_insolvency_history": false,
+  "etag": "f9a266b93e2b68db278aad8addfdaceb814ad996",
+  "has_charges": false,
+  "company_status": "active",
+  "confirmation_statement": {
+    "next_made_up_to": "2019-05-09",
+    "next_due": "2019-05-23",
+    "overdue": false,
+    "last_made_up_to": "2018-05-09"
+  },
+  "links": {
+    "self": "/company/SC028747",
+    "filing_history": "/company/SC028747/filing-history",
+    "officers": "/company/SC028747/officers",
+    "persons_with_significant_control": "/company/SC028747/persons-with-significant-control"
+  },
+  "registered_office_is_in_dispute": false,
+  "can_file": true
+}

--- a/src/main/resources/mocks/companies/SO302113.json
+++ b/src/main/resources/mocks/companies/SO302113.json
@@ -1,0 +1,54 @@
+{
+  "registered_office_address": {
+    "postal_code": "EH1 2BB",
+    "address_line_1": "19 Rutland Square",
+    "locality": "Edinburgh"
+  },
+  "company_number": "SO302113",
+  "date_of_creation": "2008-10-30",
+  "jurisdiction": "scotland",
+  "type": "llp",
+  "undeliverable_registered_office_address": false,
+  "company_name": "KLG SCOTLAND LLP",
+  "has_been_liquidated": false,
+  "status": "active",
+  "accounts": {
+    "overdue": false,
+    "next_made_up_to": "2018-03-31",
+    "next_accounts": {
+      "period_end_on": "2018-03-31",
+      "overdue": false,
+      "period_start_on": "2017-04-01",
+      "due_on": "2018-12-31"
+    },
+    "next_due": "2018-12-31",
+    "last_accounts": {
+      "made_up_to": "2017-03-31",
+      "period_start_on": "2016-04-01",
+      "period_end_on": "2017-03-31"
+    },
+    "accounting_reference_date": {
+      "day": "31",
+      "month": "03"
+    }
+  },
+  "has_insolvency_history": false,
+  "etag": "279e7d355dad6617362011792d7e9c084d16692c",
+  "has_charges": true,
+  "company_status": "active",
+  "confirmation_statement": {
+    "next_due": "2018-11-13",
+    "overdue": false,
+    "last_made_up_to": "2017-10-30",
+    "next_made_up_to": "2018-10-30"
+  },
+  "links": {
+    "self": "/company/SO302113",
+    "filing_history": "/company/SO302113/filing-history",
+    "officers": "/company/SO302113/officers",
+    "charges": "/company/SO302113/charges",
+    "persons_with_significant_control": "/company/SO302113/persons-with-significant-control"
+  },
+  "registered_office_is_in_dispute": false,
+  "can_file": false
+}

--- a/src/main/resources/mocks/companies/not_found.json
+++ b/src/main/resources/mocks/companies/not_found.json
@@ -1,0 +1,8 @@
+{
+  "errors": [
+    {
+      "type": "ch:service",
+      "error": "company-profile-not-found"
+    }
+  ]
+}

--- a/src/test/java/uk/gov/ea/wastecarrier/services/CompaniesHouseHelperTest.java
+++ b/src/test/java/uk/gov/ea/wastecarrier/services/CompaniesHouseHelperTest.java
@@ -1,0 +1,35 @@
+package uk.gov.ea.wastecarrier.services;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import uk.gov.ea.wastecarrier.services.helper.mocks.CompaniesHouseHelper;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class CompaniesHouseHelperTest {
+
+    private static CompaniesHouseHelper helper;
+
+    @BeforeClass
+    public static void setup() {
+        helper = new CompaniesHouseHelper();
+    }
+
+    @Test
+    public void response() {
+        String result = helper.response("00445790");
+        assertTrue("Company name is TESCO PLC", result.contains("TESCO PLC"));
+        assertTrue("Is active ",result.contains("active"));
+    }
+
+    @Test
+    public void responseCompanyNumberIsNull() {
+        assertEquals("{}", helper.response(null));
+    }
+
+    @Test
+    public void companyCompanyNumberIsNotFound() {
+        assertTrue(helper.response("99999999").contains("company-profile-not-found"));
+    }
+}

--- a/src/test/java/uk/gov/ea/wastecarrier/services/WorldpayHelperTest.java
+++ b/src/test/java/uk/gov/ea/wastecarrier/services/WorldpayHelperTest.java
@@ -3,7 +3,7 @@ package uk.gov.ea.wastecarrier.services;
 import org.junit.*;
 import org.w3c.dom.Document;
 import uk.gov.ea.wastecarrier.services.core.mocks.WorldpayOrder;
-import uk.gov.ea.wastecarrier.services.helper.WorldpayHelper;
+import uk.gov.ea.wastecarrier.services.helper.mocks.WorldpayHelper;
 import uk.gov.ea.wastecarrier.services.support.FixtureReader;
 import uk.gov.ea.wastecarrier.services.support.WorldpayOrderBuilder;
 

--- a/src/test/java/uk/gov/ea/wastecarrier/services/support/MockWorldpayOrderConnectionUtil.java
+++ b/src/test/java/uk/gov/ea/wastecarrier/services/support/MockWorldpayOrderConnectionUtil.java
@@ -7,6 +7,7 @@ import uk.gov.ea.wastecarrier.services.helper.SearchHelper;
 
 public class MockWorldpayOrderConnectionUtil {
 
+    public DatabaseConfiguration databaseConfig;
     public DatabaseHelper databaseHelper;
     public MockWorldpayDao dao;
     public SearchHelper searchHelper;
@@ -18,10 +19,10 @@ public class MockWorldpayOrderConnectionUtil {
         String password = System.getenv("WCRS_TEST_REGSDB_PASSWORD");
         int timeout = Integer.valueOf(System.getenv("WCRS_TEST_REGSDB_SERVER_SEL_TIMEOUT"));
 
-        DatabaseConfiguration config = new DatabaseConfiguration(url, name, username, password, timeout);
+        this.databaseConfig = new DatabaseConfiguration(url, name, username, password, timeout);
 
-        databaseHelper = new DatabaseHelper(config);
-        dao = new MockWorldpayDao(config);
+        databaseHelper = new DatabaseHelper(this.databaseConfig);
+        dao = new MockWorldpayDao(this.databaseConfig);
         searchHelper = new SearchHelper(databaseHelper, dao);
     }
 

--- a/src/test/java/uk/gov/ea/wastecarrier/services/support/WorldpayOrderBuilder.java
+++ b/src/test/java/uk/gov/ea/wastecarrier/services/support/WorldpayOrderBuilder.java
@@ -1,7 +1,7 @@
 package uk.gov.ea.wastecarrier.services.support;
 
 import uk.gov.ea.wastecarrier.services.core.mocks.WorldpayOrder;
-import uk.gov.ea.wastecarrier.services.helper.WorldpayHelper;
+import uk.gov.ea.wastecarrier.services.helper.mocks.WorldpayHelper;
 
 import java.util.Date;
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-408

These changes add the ability for the waste-carriers-service to 'mock' Companies House.

In cases where we need to carry out performance testing we don't want to hit the actual services, for example OS Places for address lookup and Worldpay for payments.

We could have built a separate companies-house-mock-app but then that would mean deploying an extra app just for when we need to do performance testing.

By building it into the service, we simply need to change the env var which holds the url for Companies House to point to our local instance, and we are able to begin mocking it.