### PR TITLE
Ensure seed data is archived in Jenkins build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,6 +19,11 @@ pipeline {
         always {
             archiveArtifacts artifacts: 'target/*.jar', onlyIfSuccessful: true
             archiveArtifacts artifacts: 'configuration.yml', onlyIfSuccessful: true
+            archiveArtifacts artifacts: 'src/test/resources/entity_data/entities.csv', onlyIfSuccessful: true
+            archiveArtifacts artifacts: 'src/test/resources/ir_renewal_data/irdata_company.csv', onlyIfSuccessful: true
+            archiveArtifacts artifacts: 'src/test/resources/ir_renewal_data/irdata_individual.csv', onlyIfSuccessful: true
+            archiveArtifacts artifacts: 'src/test/resources/ir_renewal_data/irdata_partners.csv', onlyIfSuccessful: true
+            archiveArtifacts artifacts: 'src/test/resources/ir_renewal_data/irdata_publicbody.csv', onlyIfSuccessful: true
             cleanWs cleanWhenFailure: false
         }
     }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-133

We need to be able to seed our service in none production environments, and typically we have used the test fixtures to do this.

When it comes to Jenkins though it won't see those files if we have not told it to archive them during the build. Hence this change.