### PR TITLE
Refactor mongoid config to use URI's

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,8 @@
 env:
   global:
-    - WCRS_TEST_REGSDB_URL1="localhost:27017"
-    - WCRS_TEST_REGSDB_NAME=waste-carriers-test
-    - WCRS_TEST_REGSDB_USERNAME=mongoUser
-    - WCRS_TEST_REGSDB_PASSWORD=password1234
-    - WCRS_TEST_REGSDB_SERVER_SEL_TIMEOUT=1000
-    - WCRS_TEST_USERSDB_URL1="localhost:27017"
-    - WCRS_TEST_USERSDB_NAME=waste-carriers-users-test
-    - WCRS_TEST_USERSDB_USERNAME=mongoUser
-    - WCRS_TEST_USERSDB_PASSWORD=password1234
-    - WCRS_TEST_USERSDB_SERVER_SEL_TIMEOUT=1000
+    - WCRS_TEST_REGSDB_URI="mongodb://mongoUser:password1234@localhost:27017/waste-carriers-test"
+    - WCRS_TEST_USERSDB_URI="mongodb://mongoUser:password1234@localhost:27017/waste-carriers-users-test"
+    - WCRS_TEST_MONGODB_SERVER_SEL_TIMEOUT=1000
 
 language: java
 

--- a/configuration.yml
+++ b/configuration.yml
@@ -42,25 +42,19 @@ server:
 
 # Registrations database connection properties
 database:
-  url: ${WCRS_REGSDB_URL1:-localhost:27017}
-  name: ${WCRS_REGSDB_NAME:-waste-carriers}
-  username: ${WCRS_REGSDB_USERNAME:-mongoUser}
-  password: ${WCRS_REGSDB_PASSWORD:-password1234}
+  uri: ${WCRS_REGSDB_URI:-mongodb://mongoUser:password1234@localhost:27017/waste-carriers}
   # Server selection timeout is the number of milliseconds the mongo driver will
   # wait to select a server for an operation before giving up and raising an
   # error. The default should be left in production but in dev and test it
   # allows for quicker tests and failures
   # For details of other options you can set check out
   # http://api.mongodb.com/java/3.0/?com/mongodb/MongoClientOptions.html
-  serverSelectionTimeout: ${WCRS_REGSDB_SERVER_SEL_TIMEOUT:-30000}
+  serverSelectionTimeout: ${WCRS_MONGODB_SERVER_SEL_TIMEOUT:-30000}
 
 # Users database connection properties
 userDatabase:
-  url: ${WCRS_USERSDB_URL1:-localhost:27017}
-  name: ${WCRS_USERSDB_NAME:-waste-carriers-users}
-  username: ${WCRS_USERSDB_USERNAME:-mongoUser}
-  password: ${WCRS_USERSDB_PASSWORD:-password1234}
-  serverSelectionTimeout: ${WCRS_USERSDB_SERVER_SEL_TIMEOUT:-30000}
+  uri: ${WCRS_USERSDB_URI:-mongodb://mongoUser:password1234@localhost:27017/waste-carriers-users}
+  serverSelectionTimeout: ${WCRS_MONGODB_SERVER_SEL_TIMEOUT:-30000}
 
 settings:
   # registration period (in years)

--- a/src/main/java/uk/gov/ea/wastecarrier/services/DatabaseConfiguration.java
+++ b/src/main/java/uk/gov/ea/wastecarrier/services/DatabaseConfiguration.java
@@ -4,87 +4,56 @@ import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.mongodb.Mongo;
+import com.mongodb.MongoClientURI;
 import org.hibernate.validator.constraints.NotEmpty;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 public class DatabaseConfiguration {
+
     @NotEmpty
     @JsonProperty
-    private String url;
-
-    private String host;
-
-    private int port;
-    
-    @NotEmpty
-    @JsonProperty
-    private String name;
-    
-    @JsonProperty
-    private String username;
-
-    @JsonProperty
-    private String password;
+    private String uri;
 
     @Min(1000)
     @Max(60000)
     @JsonProperty
     private int serverSelectionTimeout;
 
+    private MongoClientURI mongoClientURI;
+
     public DatabaseConfiguration() {}
 
-    public DatabaseConfiguration(
-            String url,
-            String name,
-            String username,
-            String password,
-            int serverSelectionTimeout
-    ) {
-        this.url = url;
-        this.name = name;
-        this.username = username;
-        this.password = password;
+    public DatabaseConfiguration(String uri, int serverSelectionTimeout) {
+        this.uri = uri;
         this.serverSelectionTimeout = serverSelectionTimeout;
-
-        setHostAndPort();
     }
 
-    public String getUrl() {
-        return this.url;
+    public String getUri() {
+        return this.uri;
     }
 
-    public String getHost() {
-        if (this.host == null || this.host.isEmpty()) setHostAndPort();
+    public MongoClientURI getMongoClientURI() {
 
-        return host;
-    }
+        if (this.mongoClientURI == null) {
+            this.mongoClientURI = new MongoClientURI(includeServerSelectionTimeoutMS(uri, serverSelectionTimeout));
+        }
 
-    public int getPort() {
-        if (this.port == 0) setHostAndPort();
-
-        return port;
-    }
-    
-    public String getName() {
-        return name;
-    }
-
-    public String getUsername()
-    {
-        return username;
-    }
-
-    public String getPassword()
-    {
-        return password;
+        return this.mongoClientURI;
     }
 
     public int getServerSelectionTimeout() {
         return serverSelectionTimeout;
     }
 
-    private void setHostAndPort() {
-        String[] parts = this.url.split(":");
-        this.host = parts[0];
-        this.port = Integer.valueOf(parts[1]);
+    private String includeServerSelectionTimeoutMS(String uri, int serverSelectionTimeout) {
+        if (uri.endsWith("?")) {
+            return uri + "&serverSelectionTimeoutMS=" + String.valueOf(serverSelectionTimeout);
+        }
+        else {
+            return uri + "?serverSelectionTimeoutMS=" + String.valueOf(serverSelectionTimeout);
+        }
     }
 }

--- a/src/main/java/uk/gov/ea/wastecarrier/services/backgroundJobs/BackgroundJobScheduler.java
+++ b/src/main/java/uk/gov/ea/wastecarrier/services/backgroundJobs/BackgroundJobScheduler.java
@@ -176,12 +176,7 @@ public class BackgroundJobScheduler implements Managed
             .build();
 
         JobDataMap dataMap = exportJob.getJobDataMap();
-        dataMap.put(ExportJob.DATABASE_URL, databaseConfig.getUrl());
-        dataMap.put(ExportJob.DATABASE_HOST, databaseConfig.getHost());
-        dataMap.put(ExportJob.DATABASE_PORT, databaseConfig.getPort());
-        dataMap.put(ExportJob.DATABASE_NAME, databaseConfig.getName());
-        dataMap.put(ExportJob.DATABASE_USERNAME, databaseConfig.getUsername());
-        dataMap.put(ExportJob.DATABASE_PASSWORD, databaseConfig.getPassword());
+        dataMap.put(ExportJob.DATABASE_URI, databaseConfig.getUri());
         dataMap.put(ExportJob.DATABASE_TIMEOUT, databaseConfig.getServerSelectionTimeout());
         dataMap.put(ExportJob.EPR_EXPORT_FILE, exportJobConfig.getEprExportFile());
         dataMap.put(ExportJob.EPR_DATE_FORMAT, exportJobConfig.getEprExportDateFormat());
@@ -217,12 +212,7 @@ public class BackgroundJobScheduler implements Managed
                 .build();
         
         JobDataMap dataMap = regStatusJob.getJobDataMap();
-        dataMap.put(RegistrationStatusJob.DATABASE_URL, databaseConfig.getUrl());
-        dataMap.put(RegistrationStatusJob.DATABASE_HOST, databaseConfig.getHost());
-        dataMap.put(RegistrationStatusJob.DATABASE_PORT, databaseConfig.getPort());
-        dataMap.put(RegistrationStatusJob.DATABASE_NAME, databaseConfig.getName());
-        dataMap.put(RegistrationStatusJob.DATABASE_USERNAME, databaseConfig.getUsername());
-        dataMap.put(RegistrationStatusJob.DATABASE_PASSWORD, databaseConfig.getPassword());
+        dataMap.put(RegistrationStatusJob.DATABASE_URI, databaseConfig.getUri());
         dataMap.put(RegistrationStatusJob.DATABASE_TIMEOUT, databaseConfig.getServerSelectionTimeout());
 
         return regStatusJob;

--- a/src/main/java/uk/gov/ea/wastecarrier/services/backgroundJobs/ExportJob.java
+++ b/src/main/java/uk/gov/ea/wastecarrier/services/backgroundJobs/ExportJob.java
@@ -46,12 +46,7 @@ public class ExportJob implements Job
 {
     // Public 'constants' used in the JobDataMap, which passes configuration
     // to this job.
-    public static final String DATABASE_URL = "database_url";
-    public static final String DATABASE_HOST = "database_host";
-    public static final String DATABASE_PORT = "database_port";
-    public static final String DATABASE_NAME = "database_name";
-    public static final String DATABASE_USERNAME = "database_username";
-    public static final String DATABASE_PASSWORD = "database_password";
+    public static final String DATABASE_URI = "database_uri";
     public static final String DATABASE_TIMEOUT = "database_timeout";
 
     public static final String EPR_EXPORT_FILE = "epr_export_file";
@@ -167,10 +162,6 @@ public class ExportJob implements Job
             
             // Log job configuration for debugging purposes.
             JobDataMap jobConfig = context.getJobDetail().getJobDataMap();
-            log.fine(String.format("--> Will attempt to use database %s on %s",
-                jobConfig.getString(DATABASE_NAME),
-                jobConfig.getString(DATABASE_URL)
-            ));
             log.fine(String.format("--> The EPR export file is %s", jobConfig.getString(EPR_EXPORT_FILE)));
             log.fine(String.format("--> The EPR date format is %s", jobConfig.getString(EPR_DATE_FORMAT)));
             log.fine(String.format("--> The Reporting export path is %s", jobConfig.getString(REPORTING_EXPORT_PATH)));
@@ -189,10 +180,7 @@ public class ExportJob implements Job
             // Build a database helper using the provided configuration.
             dbHelper = new DatabaseHelper(
                     new DatabaseConfiguration(
-                            jobConfig.getString(DATABASE_URL),
-                            jobConfig.getString(DATABASE_NAME),
-                            jobConfig.getString(DATABASE_USERNAME),
-                            jobConfig.getString(DATABASE_PASSWORD),
+                            jobConfig.getString(DATABASE_URI),
                             jobConfig.getInt(DATABASE_TIMEOUT)
                     )
             );

--- a/src/main/java/uk/gov/ea/wastecarrier/services/cli/IRImporter.java
+++ b/src/main/java/uk/gov/ea/wastecarrier/services/cli/IRImporter.java
@@ -149,8 +149,7 @@ public class IRImporter extends ConfiguredCommand<WasteCarrierConfiguration>
      * @throws Exception 
      */
     @Override
-    public void run(Bootstrap<WasteCarrierConfiguration> bootstrap, Namespace namespace, WasteCarrierConfiguration configuration) throws Exception
-    {
+    public void run(Bootstrap<WasteCarrierConfiguration> bootstrap, Namespace namespace, WasteCarrierConfiguration configuration) throws Exception {
         // Output useful logging.
         System.out.println("IR-Import command starting");
         System.out.println(String.format(" - will attempt to import from %s", namespace.getString("source")));
@@ -168,18 +167,11 @@ public class IRImporter extends ConfiguredCommand<WasteCarrierConfiguration>
         DatabaseConfiguration dbConfig = configuration.getDatabase();
         
         // Build a database helper.
-        DatabaseHelper dbHelper = new DatabaseHelper(new DatabaseConfiguration(
-                dbConfig.getUrl(),
-                dbConfig.getName(),
-                dbConfig.getUsername(),
-                dbConfig.getPassword(),
-                dbConfig.getServerSelectionTimeout()
-        ));
+        DatabaseHelper dbHelper = new DatabaseHelper(dbConfig);
         
         // Check we can connect to the database, and are authenticated.
         DB db = dbHelper.getConnection();
-        if (db == null)
-        {
+        if (db == null) {
             throw new RuntimeException("Error: No database connection available; aborting.");
         }
         

--- a/src/main/java/uk/gov/ea/wastecarrier/services/helper/DatabaseHelper.java
+++ b/src/main/java/uk/gov/ea/wastecarrier/services/helper/DatabaseHelper.java
@@ -22,11 +22,6 @@ public class DatabaseHelper {
     private DatabaseConfiguration dbConfig;
 
     public DatabaseHelper(DatabaseConfiguration database) {
-
-        // Get connection properties from environment settings
-        log.logp(Level.FINE, DatabaseHelper.class.getName(), "DatabaseHelper",
-                "Init DatabaseHelper using database params: " + database.getName()+ " " + database.getHost() +":"+ database.getPort());
-
         // Save configuration
         this.dbConfig = database;
     }
@@ -46,7 +41,7 @@ public class DatabaseHelper {
                 return db;
             }
             catch (Exception e) {
-                log.severe("Could not connect to database " + this.dbConfig.getName() + ": " + e.getMessage());
+                log.severe("Could not connect to database " + this.dbConfig.getMongoClientURI().getDatabase() + ": " + e.getMessage());
                 return null;
             }
         } else {
@@ -55,10 +50,10 @@ public class DatabaseHelper {
             MongoClient mc = getMongoClient();
             try {
                 // Get Specific database
-                db = mc.getDB(dbConfig.getName());
+                db = mc.getDB(dbConfig.getMongoClientURI().getDatabase());
             }
             catch (Exception e) {
-                log.severe("Database connection not found " + this.dbConfig.getName() + ": " + e.getMessage());
+                log.severe("Database connection not found " + this.dbConfig.getMongoClientURI().getDatabase() + ": " + e.getMessage());
                 db = null;
                 return null;
             }
@@ -75,23 +70,7 @@ public class DatabaseHelper {
         if (mongoClient != null) {
             return mongoClient;
         } else {
-            MongoCredential credential = MongoCredential.createCredential(
-                    dbConfig.getUsername(),
-                    dbConfig.getName(),
-                    dbConfig.getPassword().toCharArray()
-            );
-            ServerAddress server = new ServerAddress(dbConfig.getHost(), dbConfig.getPort());
-
-            MongoClientOptions options = MongoClientOptions
-                    .builder()
-                    .serverSelectionTimeout(
-                        dbConfig.getServerSelectionTimeout()
-                    )
-                    .build();
-
-            MongoClient client = new MongoClient(server, credential, options);
-
-            this.mongoClient = client;
+            this.mongoClient = new MongoClient(this.dbConfig.getMongoClientURI());
 
             return mongoClient;
         }

--- a/src/test/java/uk/gov/ea/wastecarrier/services/DatabaseConfigurationTest.java
+++ b/src/test/java/uk/gov/ea/wastecarrier/services/DatabaseConfigurationTest.java
@@ -1,0 +1,44 @@
+package uk.gov.ea.wastecarrier.services;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class DatabaseConfigurationTest {
+
+    @Test
+    public void initializeWithLocalUri() {
+        DatabaseConfiguration dbConfig = new DatabaseConfiguration(
+                "mongodb://mongoUser:password1234@localhost:27017/waste-carriers",
+                1000
+        );
+
+        assertEquals("waste-carriers", dbConfig.getMongoClientURI().getDatabase());
+        assertEquals("mongoUser", dbConfig.getMongoClientURI().getUsername());
+    }
+
+    @Test
+    public void initializeUriIncludesServerSelectionTimeout() {
+        DatabaseConfiguration dbConfig = new DatabaseConfiguration(
+                "mongodb://mongoUser:password1234@localhost:27017/waste-carriers",
+                1000
+        );
+
+        assertEquals(
+                "mongodb://mongoUser:password1234@localhost:27017/waste-carriers?serverSelectionTimeoutMS=1000",
+                dbConfig.getMongoClientURI().getURI()
+        );
+        assertEquals(1000, dbConfig.getMongoClientURI().getOptions().getServerSelectionTimeout());
+    }
+
+    @Test
+    public void initializeWithProductionUri() {
+        DatabaseConfiguration dbConfig = new DatabaseConfiguration(
+                "mongodb://mongoUser:password1234@mongodb1:27017,mongodb2:27017,mongodb3:27017/waste-carriers?replicaSet=wcrepl",
+                1000
+        );
+
+        assertEquals("waste-carriers", dbConfig.getMongoClientURI().getDatabase());
+        assertEquals("mongoUser", dbConfig.getMongoClientURI().getUsername());
+    }
+}

--- a/src/test/java/uk/gov/ea/wastecarrier/services/support/EntityMatchingConnectionUtil.java
+++ b/src/test/java/uk/gov/ea/wastecarrier/services/support/EntityMatchingConnectionUtil.java
@@ -12,13 +12,10 @@ public class EntityMatchingConnectionUtil {
     public SearchHelper searchHelper;
 
     public EntityMatchingConnectionUtil() {
-        String url  = System.getenv("WCRS_TEST_REGSDB_URL1");
-        String name = System.getenv("WCRS_TEST_REGSDB_NAME");
-        String username = System.getenv("WCRS_TEST_REGSDB_USERNAME");
-        String password = System.getenv("WCRS_TEST_REGSDB_PASSWORD");
-        int timeout = Integer.valueOf(System.getenv("WCRS_TEST_REGSDB_SERVER_SEL_TIMEOUT"));
+        String uri = System.getenv("WCRS_TEST_REGSDB_URI");
+        int timeout = Integer.valueOf(System.getenv("WCRS_TEST_MONGODB_SERVER_SEL_TIMEOUT"));
 
-        DatabaseConfiguration config = new DatabaseConfiguration(url, name, username, password, timeout);
+        DatabaseConfiguration config = new DatabaseConfiguration(uri, timeout);
 
         databaseHelper = new DatabaseHelper(config);
         dao = new EntityDao(config);
@@ -30,11 +27,12 @@ public class EntityMatchingConnectionUtil {
     }
 
     public EntityDao invalidCredentialsDao() {
+        String validUsername = this.databaseHelper.configuration().getMongoClientURI().getUsername();
+        String validUri = this.databaseHelper.configuration().getMongoClientURI().getURI();
+
+        String invalidUri = validUri.replaceFirst(validUsername, "lockedOut");
         DatabaseConfiguration invalidConfig = new DatabaseConfiguration(
-                this.databaseHelper.configuration().getUrl(),
-                this.databaseHelper.configuration().getName(),
-                this.databaseHelper.configuration().getUsername(),
-                "Bl0wMeDownWithAFeather",
+                invalidUri,
                 this.databaseHelper.configuration().getServerSelectionTimeout()
         );
         return new EntityDao(invalidConfig);

--- a/src/test/java/uk/gov/ea/wastecarrier/services/support/MockWorldpayOrderConnectionUtil.java
+++ b/src/test/java/uk/gov/ea/wastecarrier/services/support/MockWorldpayOrderConnectionUtil.java
@@ -13,13 +13,10 @@ public class MockWorldpayOrderConnectionUtil {
     public SearchHelper searchHelper;
 
     public MockWorldpayOrderConnectionUtil() {
-        String url  = System.getenv("WCRS_TEST_REGSDB_URL1");
-        String name = System.getenv("WCRS_TEST_REGSDB_NAME");
-        String username = System.getenv("WCRS_TEST_REGSDB_USERNAME");
-        String password = System.getenv("WCRS_TEST_REGSDB_PASSWORD");
-        int timeout = Integer.valueOf(System.getenv("WCRS_TEST_REGSDB_SERVER_SEL_TIMEOUT"));
+        String uri = System.getenv("WCRS_TEST_REGSDB_URI");
+        int timeout = Integer.valueOf(System.getenv("WCRS_TEST_MONGODB_SERVER_SEL_TIMEOUT"));
 
-        this.databaseConfig = new DatabaseConfiguration(url, name, username, password, timeout);
+        this.databaseConfig = new DatabaseConfiguration(uri, timeout);
 
         databaseHelper = new DatabaseHelper(this.databaseConfig);
         dao = new MockWorldpayDao(this.databaseConfig);
@@ -31,11 +28,12 @@ public class MockWorldpayOrderConnectionUtil {
     }
 
     public MockWorldpayDao invalidCredentialsDao() {
+        String validUsername = this.databaseHelper.configuration().getMongoClientURI().getUsername();
+        String validUri = this.databaseHelper.configuration().getMongoClientURI().getURI();
+
+        String invalidUri = validUri.replaceFirst(validUsername, "lockedOut");
         DatabaseConfiguration invalidConfig = new DatabaseConfiguration(
-                this.databaseHelper.configuration().getUrl(),
-                this.databaseHelper.configuration().getName(),
-                this.databaseHelper.configuration().getUsername(),
-                "Bl0wMeDownWithAFeather",
+                invalidUri,
                 this.databaseHelper.configuration().getServerSelectionTimeout()
         );
         return new MockWorldpayDao(invalidConfig);

--- a/src/test/java/uk/gov/ea/wastecarrier/services/support/RegistrationsConnectionUtil.java
+++ b/src/test/java/uk/gov/ea/wastecarrier/services/support/RegistrationsConnectionUtil.java
@@ -12,13 +12,10 @@ public class RegistrationsConnectionUtil {
     public SearchHelper searchHelper;
 
     public RegistrationsConnectionUtil()  {
-        String url  = System.getenv("WCRS_TEST_REGSDB_URL1");
-        String name = System.getenv("WCRS_TEST_REGSDB_NAME");
-        String username = System.getenv("WCRS_TEST_REGSDB_USERNAME");
-        String password = System.getenv("WCRS_TEST_REGSDB_PASSWORD");
-        int timeout = Integer.valueOf(System.getenv("WCRS_TEST_REGSDB_SERVER_SEL_TIMEOUT"));
+        String uri = System.getenv("WCRS_TEST_REGSDB_URI");
+        int timeout = Integer.valueOf(System.getenv("WCRS_TEST_MONGODB_SERVER_SEL_TIMEOUT"));
 
-        DatabaseConfiguration config = new DatabaseConfiguration(url, name, username, password, timeout);
+        DatabaseConfiguration config = new DatabaseConfiguration(uri, timeout);
 
         databaseHelper = new DatabaseHelper(config);
         dao = new RegistrationDao(config);
@@ -30,11 +27,12 @@ public class RegistrationsConnectionUtil {
     }
 
     public RegistrationDao invalidCredentialsDao() {
+        String validUsername = this.databaseHelper.configuration().getMongoClientURI().getUsername();
+        String validUri = this.databaseHelper.configuration().getMongoClientURI().getURI();
+
+        String invalidUri = validUri.replaceFirst(validUsername, "lockedOut");
         DatabaseConfiguration invalidConfig = new DatabaseConfiguration(
-                this.databaseHelper.configuration().getUrl(),
-                this.databaseHelper.configuration().getName(),
-                this.databaseHelper.configuration().getUsername(),
-                "Bl0wMeDownWithAFeather",
+                invalidUri,
                 this.databaseHelper.configuration().getServerSelectionTimeout()
         );
         return new RegistrationDao(invalidConfig);

--- a/src/test/java/uk/gov/ea/wastecarrier/services/support/UsersConnectionUtil.java
+++ b/src/test/java/uk/gov/ea/wastecarrier/services/support/UsersConnectionUtil.java
@@ -12,13 +12,10 @@ public class UsersConnectionUtil {
     public UserDao dao;
 
     public UsersConnectionUtil() {
-        String url  = System.getenv("WCRS_TEST_USERSDB_URL1");
-        String name = System.getenv("WCRS_TEST_USERSDB_NAME");
-        String username = System.getenv("WCRS_TEST_USERSDB_USERNAME");
-        String password = System.getenv("WCRS_TEST_USERSDB_PASSWORD");
-        int timeout = Integer.valueOf(System.getenv("WCRS_TEST_USERSDB_SERVER_SEL_TIMEOUT"));
+        String uri = System.getenv("WCRS_TEST_REGSDB_URI");
+        int timeout = Integer.valueOf(System.getenv("WCRS_TEST_MONGODB_SERVER_SEL_TIMEOUT"));
 
-        DatabaseConfiguration config = new DatabaseConfiguration(url, name, username, password, timeout);
+        DatabaseConfiguration config = new DatabaseConfiguration(uri, timeout);
 
         databaseHelper = new DatabaseHelper(config);
         dao = new UserDao(config);
@@ -45,11 +42,12 @@ public class UsersConnectionUtil {
     }
 
     public UserDao invalidCredentialsDao() {
+        String validUsername = this.databaseHelper.configuration().getMongoClientURI().getUsername();
+        String validUri = this.databaseHelper.configuration().getMongoClientURI().getURI();
+
+        String invalidUri = validUri.replaceFirst(validUsername, "lockedOut");
         DatabaseConfiguration invalidConfig = new DatabaseConfiguration(
-                this.databaseHelper.configuration().getUrl(),
-                this.databaseHelper.configuration().getName(),
-                this.databaseHelper.configuration().getUsername(),
-                "Bl0wMeDownWithAFeather",
+                invalidUri,
                 this.databaseHelper.configuration().getServerSelectionTimeout()
         );
         return new UserDao(invalidConfig);

--- a/test_env_vars.sh
+++ b/test_env_vars.sh
@@ -2,14 +2,7 @@
 
 # source test_env_vars.sh
 
-export WCRS_TEST_REGSDB_URL1="localhost:27017"
-export WCRS_TEST_REGSDB_NAME=waste-carriers-test
-export WCRS_TEST_REGSDB_USERNAME=mongoUser
-export WCRS_TEST_REGSDB_PASSWORD=password1234
-export WCRS_TEST_REGSDB_SERVER_SEL_TIMEOUT=1000
+export WCRS_TEST_REGSDB_URI="mongodb://mongoUser:password1234@localhost:27017/waste-carriers-test"
+export WCRS_TEST_USERSDB_URI="mongodb://mongoUser:password1234@localhost:27017/waste-carriers-users-test"
 
-export WCRS_TEST_USERSDB_URL1="localhost:27017"
-export WCRS_TEST_USERSDB_NAME=waste-carriers-users-test
-export WCRS_TEST_USERSDB_USERNAME=mongoUser
-export WCRS_TEST_USERSDB_PASSWORD=password1234
-export WCRS_TEST_USERSDB_SERVER_SEL_TIMEOUT=1000
+export WCRS_TEST_MONGODB_SERVER_SEL_TIMEOUT=1000


### PR DESCRIPTION
Previously we had specified each of the parameters that make up a connection to the databases within the `mongoid.yml` file. The documentation for the file is heavily centred on this kind of way of doing it <https://docs.mongodb.com/mongoid/master/tutorials/mongoid-installation/#anatomy-of-a-mongoid-config>.

So database, hosts, user, password etc are all listed out. However commented out is mention of providing a URI which has all the details included. Our web-ops team were pushing for using this format and after some investigation

- it looks like this is how we currently do it for our existing app when running in production
- though not scientific, some investigation online suggests this is the typical way to do it when running in production

So this change is about following conventions and switching the app to follow convention and use the URI. The one decision we have made is rather than maintaining both a URI and bunch of env vars that just duplicate the same info, we will use the URI format in all environments.