### PR TITLE
Remove version from jar & simplify pom.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Other values in the configuration file have a default, however you can override 
 Alternatively, you can create another local configuration file with your values in it, and refer to this file when starting up the service.
 
 ```bash
-java -jar target/waste-carriers-service*.jar server my_configuration.yml
+java -jar target/waste-carriers-service.jar server my_configuration.yml
 ```
 
 ## Build
@@ -65,13 +65,13 @@ N.B. If maven was installed all on the machine you would swap `./mvnw` with `mvn
 Start the service by providing the name of the jar file, the command 'server', and the name of the configuration file.
 
 ```bash
-java -jar target/waste-carriers-service*.jar server  configuration.yml
+java -jar target/waste-carriers-service.jar server  configuration.yml
 ```
 
 You can also override parameters such as https port numbers using the Java '-D' option.
 
 ```bash
-java -Ddw.http.port=8003 -Ddw.http.adminPort=8004 -jar target/waste-carriers-service-1.1.2.jar server my_configuration.yml
+java -Ddw.http.port=8003 -Ddw.http.adminPort=8004 -jar target/waste-carriers-service.jar server my_configuration.yml
 ```
 
 For more details on how to start a Dropwizard service and configuration and startup options, please see the Dropwizard documentation.

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,7 @@
         </dependency>
     </dependencies>
     <build>
+        <finalName>${project.artifactId}</finalName>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -79,32 +80,20 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <version>1.2.1</version>
-                <configuration>
-                    <mainClass>uk.gov.ea.wastecarrier.services.WasteCarrierService</mainClass>
-                    <arguments>
-                        <argument>server</argument>
-                        <argument>configuration.yml</argument>
-                    </arguments>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>1.6</version>
+                <version>2.3</version>
                 <configuration>
                     <createDependencyReducedPom>true</createDependencyReducedPom>
                     <filters>
-                    <filter>
-                        <artifact>*:*</artifact>
-                        <excludes>
-                            <exclude>META-INF/*.SF</exclude>
-                            <exclude>META-INF/*.DSA</exclude>
-                            <exclude>META-INF/*.RSA</exclude>
-                        </excludes>
-                    </filter>
+                        <filter>
+                            <artifact>*:*</artifact>
+                            <excludes>
+                                <exclude>META-INF/*.SF</exclude>
+                                <exclude>META-INF/*.DSA</exclude>
+                                <exclude>META-INF/*.RSA</exclude>
+                            </excludes>
+                        </filter>
                     </filters>
                 </configuration>
                 <executions>
@@ -124,18 +113,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>2.3.2</version>
-                <configuration>
-                    <archive>
-                        <manifest>
-                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
-                        </manifest>
-                    </archive>
-                </configuration>
-            </plugin>
-      </plugins>
-  </build>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
Whilst working on the systemd scripts that will be used to control the service in production, we faced an issue that we had to pass the `ExecStart` command to `/bin/bash -c` because we could not use our standard way of executing the service using `java -jar target/waste-carriers-service*.jar`.

We have to use the * because prior to this change the current version of the project would be included in the outputted jar file. Using the * meant we could use a generic command in scripts and documents and not have to worry about what the actual jar file name was.

On reflection we felt there was actually no need to record this fat in the Jar. We tag our releases in the git repo, and as the version only gets updated on major changes it was reasonably meaningless anyway.

Therefore this change updates the `pom.xml` build configuration to exclude the version info from the jar file name. This in turn means we always know what the filename will be, and we no longer have to make use of the *.

---

Also whilst we were in the `pom.xml` we reviewed what build plugins we had compared to the os-places-address-lookup project, and the current Dropwizard documentation. We realised we were depending on plugins those other projects didn't have (and to be honest we don't know why).

So we tried removing them (and updating the one we retained) and found that it still built and run fine, and in fact meant we went from a build time of 2mins 40secs to just 14secs. Result!