### PR TITLE
Fix error when adding timeout to MongoDb con. url

### DIFF
--- a/src/main/java/uk/gov/ea/wastecarrier/services/DatabaseConfiguration.java
+++ b/src/main/java/uk/gov/ea/wastecarrier/services/DatabaseConfiguration.java
@@ -49,7 +49,7 @@ public class DatabaseConfiguration {
     }
 
     private String includeServerSelectionTimeoutMS(String uri, int serverSelectionTimeout) {
-        if (uri.endsWith("?")) {
+        if (uri.contains("?")) {
             return uri + "&serverSelectionTimeoutMS=" + String.valueOf(serverSelectionTimeout);
         }
         else {

--- a/src/test/java/uk/gov/ea/wastecarrier/services/DatabaseConfigurationTest.java
+++ b/src/test/java/uk/gov/ea/wastecarrier/services/DatabaseConfigurationTest.java
@@ -40,5 +40,6 @@ public class DatabaseConfigurationTest {
 
         assertEquals("waste-carriers", dbConfig.getMongoClientURI().getDatabase());
         assertEquals("mongoUser", dbConfig.getMongoClientURI().getUsername());
+        assertEquals("wcrepl", dbConfig.getMongoClientURI().getOptions().getRequiredReplicaSetName());
     }
 }


### PR DESCRIPTION
When checking the logs in the AWS dev environment we spotted the following error repeatedly

```
ERROR [2018-07-24 22:31:31,741] org.mongodb.driver.cluster: Expecting replica set member from set 'wcrepl?serverSelectionTimeoutMS=30000', but found one from set 'wcrepl'.  Removing mongodb1:27017 from client view of cluster.
```

When we then checked the code we found a flaw in the logic for handling a production mongodb url string that includes a replica set name, and our attempts to include a server selection timeout value.

This change updates the unit test, and fixes the issue.