### PR TITLE
Update config to read from new env var when mocked

### DIFF
--- a/configuration.yml
+++ b/configuration.yml
@@ -115,8 +115,11 @@ mock:
   worldPayAdminCode: ${WCRS_WORLDPAY_ADMIN_CODE:-ENVIRONMENTAGENCY}
   # Upon receiving the initial request from a service using worldpay, we have
   # to generate a url that the client should redirect the user to. So we need
-  # to know what our own url is within the current environment
-  servicesDomain: ${WCRS_SERVICES_DOMAIN:-http://localhost:8003}
+  # to know what our own url is within the current environment. We first
+  # look for a public domain, as that is what it would be in a production env.
+  # Else we default to what it would be when all the services are running
+  # locally
+  servicesDomain: ${WCRS_PUBLIC_DOMAIN:-http://localhost:8003}
   # The mac secret is a password shared only between Worldpay and its customers.
   # Its used along with some information from the order to sign the success
   # response. In this way the client is sure its worldpay telling them the user


### PR DESCRIPTION
When the app is run in mock mode locally, the user facing apps and the services app can talk directly. However having deployed to our production environment and tried to get this up and running, we realised that the mocked worldpay service has to act like a public service on the internet. So it can't just tell the calling app to redirect to an internal address, it must be the public address (without port number).

Hence we now look to a new env var called `WCRS_PUBLIC_DOMAIN` and if present, we use it to formulate the url the calling app should redirect users to.