### PR TITLE
Incorporate proxy values into Jenkins build cmd.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
                 // -T 1C: Thread count which means run single threaded
                 // clean: remove files from a previous build
                 // package: take the compiled code and package it into a fat JAR
-                sh "./mvnw -B -Dmaven.test.skip=true -T 1C clean package"
+                sh "./mvnw -Dhttp.proxyPort=${proxy_port} -Dhttps.proxyPort=${proxy_port} -Dhttps.proxyHost=${http_host} -Dhttp.proxyHost=${http_host} -B -Dmaven.test.skip=true -T 1C clean package"
             }
         }
     }


### PR DESCRIPTION
To ensure the project can build in an environment where a proxy server is used, we have updated the build command in the Jenkinsfile to pull in proxy values from the Jenkins job.