### PR TITLE
Correct expiry status job to ignore time

### DIFF
--- a/src/test/java/uk/gov/ea/wastecarrier/services/RegistrationStatusJobTest.java
+++ b/src/test/java/uk/gov/ea/wastecarrier/services/RegistrationStatusJobTest.java
@@ -1,0 +1,81 @@
+package uk.gov.ea.wastecarrier.services;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import uk.gov.ea.wastecarrier.services.backgroundJobs.RegistrationStatusJob;
+import uk.gov.ea.wastecarrier.services.core.MetaData;
+import uk.gov.ea.wastecarrier.services.core.Registration;
+import uk.gov.ea.wastecarrier.services.support.RegistrationBuilder;
+import uk.gov.ea.wastecarrier.services.support.RegistrationsConnectionUtil;
+import uk.gov.ea.wastecarrier.services.support.TestUtil;
+
+import java.util.Calendar;
+import java.util.Date;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class RegistrationStatusJobTest {
+
+    private static RegistrationsConnectionUtil connection;
+
+    @BeforeClass
+    public static void setup() {
+        connection = new RegistrationsConnectionUtil();
+        createRegistrations();
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        connection.clean();
+    }
+
+    @Test
+    public void expireRegistrations() {
+        RegistrationStatusJob job = new RegistrationStatusJob();
+        job.expireRegistrations(connection.dao.getCollection());
+
+        Registration reg = connection.dao.findByRegIdentifier("CBDU100");
+        assertEquals("CBDU100 is expired", MetaData.RegistrationStatus.EXPIRED, reg.getMetaData().getStatus());
+
+        reg = connection.dao.findByRegIdentifier("CBDU200");
+        assertEquals("CBDU200 is expired", MetaData.RegistrationStatus.EXPIRED, reg.getMetaData().getStatus());
+
+        reg = connection.dao.findByRegIdentifier("CBDU300");
+        assertNotEquals("CBDU300 is not expired", MetaData.RegistrationStatus.EXPIRED, reg.getMetaData().getStatus());
+
+        reg = connection.dao.findByRegIdentifier("CBDU400");
+        assertNotEquals("CBDU300 is not expired", MetaData.RegistrationStatus.EXPIRED, reg.getMetaData().getStatus());
+    }
+
+    private static void createRegistrations() {
+        // Expires today
+        Registration reg = new RegistrationBuilder(RegistrationBuilder.BuildType.UPPER)
+                .regIdentifier("CBDU100")
+                .build();
+        reg.setExpires_on(new Date());
+        connection.dao.insert(reg);
+
+        // Expires today
+        reg = new RegistrationBuilder(RegistrationBuilder.BuildType.UPPER)
+                .regIdentifier("CBDU200")
+                .build();
+        reg.setExpires_on(new Date());
+        connection.dao.insert(reg);
+
+        // Expires tomorrow
+        reg = new RegistrationBuilder(RegistrationBuilder.BuildType.UPPER)
+                .regIdentifier("CBDU300")
+                .build();
+        reg.setExpires_on(TestUtil.todayPlus(1, Calendar.DATE));
+        connection.dao.insert(reg);
+
+        // Expires in a year
+        reg = new RegistrationBuilder(RegistrationBuilder.BuildType.UPPER)
+                .regIdentifier("CBDU400")
+                .build();
+        reg.setExpires_on(TestUtil.todayPlus(1, Calendar.YEAR));
+        connection.dao.insert(reg);
+    }
+}

--- a/src/test/java/uk/gov/ea/wastecarrier/services/support/TestUtil.java
+++ b/src/test/java/uk/gov/ea/wastecarrier/services/support/TestUtil.java
@@ -3,6 +3,7 @@ package uk.gov.ea.wastecarrier.services.support;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
 public class TestUtil {
 
@@ -17,6 +18,14 @@ public class TestUtil {
         calendar.add(Calendar.DATE, days);
 
         return calendar.getTime();
+    }
+
+    public static Date todayPlus(int numberToAdd, int period) {
+        TimeZone utcTimeZone = TimeZone.getTimeZone("UTC");
+        Calendar today = Calendar.getInstance(utcTimeZone);
+        today.add(period, numberToAdd);
+
+        return today.getTime();
     }
 
     public static Date fromCurrentDate(Integer years, Integer months, Integer days) {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-186

When looking into how we determine if a registration is expired for a previous story, we had to get very specific around 'when' a registration is expired. One clear thing that came out of this work was that the time a registration is made ACTIVE does not factor into it.

The problem with the `RegistrationStatusJob` as it stood prior to this change was that its filter was based on searching for any ACTIVE registration with an expiry date less than the time the job was run.

We know in production this job is run at 8pm, so what this means is if a registration was completed 3 years ago after midnight, then it gets an extra day.

So this change updates the filter to search for any ACTIVE registration with an expiry date less than tomorrows date (with time set to 00:00). So if a registration expired on the date the job is executed at 23:59:59, it would still be caught even if the job is run at 8pm.