### PR TITLE
Add test coverage plugin and integrate CodeClimate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 env:
   global:
+    - CC_TEST_REPORTER_ID=2bdee2bd9c064b9353a674904c20c8047c95ac1c15b7580a141203d684ef5687
     - WCRS_TEST_REGSDB_URI="mongodb://mongoUser:password1234@localhost:27017/waste-carriers-test"
     - WCRS_TEST_USERSDB_URI="mongodb://mongoUser:password1234@localhost:27017/waste-carriers-users-test"
     - WCRS_TEST_MONGODB_SERVER_SEL_TIMEOUT=1000
@@ -22,5 +23,20 @@ before_script:
   # Set up Mongo databases
   - mongo waste-carriers-test --eval 'db.createUser({user:"mongoUser", pwd:"password1234", roles:["readWrite", "dbAdmin", "userAdmin"]})'
   - mongo waste-carriers-users-test --eval 'db.createUser({user:"mongoUser", pwd:"password1234", roles:["readWrite", "dbAdmin", "userAdmin"]})'
+  # Setup to support the CodeClimate test coverage submission
+  # As per CodeClimate's documentation, they suggest only running
+  # ./cc-test-reporter commands on travis-ci push builds only. Hence we wrap all
+  # the codeclimate test coverage related commands in a check that tests if we
+  # are in a pull request or not.
+  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter; fi
+  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then chmod +x ./cc-test-reporter; fi
+  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then ./cc-test-reporter before-build; fi
 
 script: ./mvnw -B -T 1C clean package
+
+after_script:
+  # In order to get this to work found we could not use the standard
+  # ./cc-test-reporter after-build but instead have to use the lower level cmds
+  # format-coverage and upload-coverage. Solved this only after finding
+  # https://github.com/codeclimate/test-reporter/issues/259#issuecomment-374280649
+  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then JACOCO_SOURCE_PATH=src/main/java ./cc-test-reporter format-coverage target/jacoco/jacoco.xml --input-type jacoco && ./cc-test-reporter upload-coverage; fi

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Waste Carriers Service
 
 [![Build Status](https://travis-ci.org/DEFRA/waste-carriers-service.svg?branch=develop)](https://travis-ci.org/DEFRA/waste-carriers-service)
+[![Maintainability](https://api.codeclimate.com/v1/badges/2931ee9159971050f098/maintainability)](https://codeclimate.com/github/DEFRA/waste-carriers-service/maintainability)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/2931ee9159971050f098/test_coverage)](https://codeclimate.com/github/DEFRA/waste-carriers-service/test_coverage)
 
 Waste Carriers Registration Service application.
 

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,40 @@
         <finalName>${project.artifactId}</finalName>
         <plugins>
             <plugin>
+                <!-- Configuration based on https://www.mkyong.com/maven/jacoco-java-code-coverage-maven-example/ -->
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.2</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>post-unit-test</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                        <configuration>
+                            <!-- Sets the path to the file which contains the execution data. -->
+                            <dataFile>target/jacoco.exec</dataFile>
+                            <!-- Sets the output directory for the code coverage report. -->
+                            <outputDirectory>target/jacoco</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.0</version>


### PR DESCRIPTION
Often it can be hard to demonstrate the technical debt a project has which may be impeding its performance. In this case we want to highlight the poor maintainability and lack of code coverage we have inherited with this project to help demonstrate why we are moving more and more functionality out of it, and how it slows us down when we changes have to be made to it.