### PR TITLE
Change default log level to ERROR

### DIFF
--- a/configuration.yml
+++ b/configuration.yml
@@ -3,8 +3,8 @@
 
 # Added standard logging information
 logging:
-  #standard logging level (should usually be INFO)
-  level: INFO
+  # logging level (we set to ERROR in production to help us identify actual issues)
+  level: ${WCRS_SERVICES_LOGLEVEL:-ERROR}
   appenders:
     # Settings for logging to stdout.
     - type: console


### PR DESCRIPTION
At the request of web-ops we are changing the default log level for the service to ERROR. They are struggling to identify issues with the service because of the amount it is outputting at the previous default of INFO.

However to allow us a little more flexibility across environments, we have also configured it to read from an ENV VAR so we can easily override it without the need to amend the config.yml file.