### PR TITLE
Add location attribute to registration

### DIFF
--- a/src/main/java/uk/gov/ea/wastecarrier/services/core/Registration.java
+++ b/src/main/java/uk/gov/ea/wastecarrier/services/core/Registration.java
@@ -77,6 +77,8 @@ public class Registration
     /*
      * These are the recorded smart answers
      */
+    @JsonProperty
+    private String location;
     @Valid
     @NotEmpty
     @JsonProperty
@@ -234,6 +236,14 @@ public class Registration
     public String getUuid()
     {
         return uuid;
+    }
+
+    /**
+     * @return the location
+     */
+    public String getLocation()
+    {
+        return location;
     }
 
     /**
@@ -443,6 +453,14 @@ public class Registration
     public void setUuid(String uuid)
     {
         this.uuid = uuid;
+    }
+
+    /**
+     * @param location the location to set
+     */
+    public void setLocation(String location)
+    {
+        this.location = location;
     }
 
     /**
@@ -769,6 +787,7 @@ public class Registration
         final Registration other = (Registration) obj;
         return Objects.equals(this.tier, other.tier)
                 && Objects.equals(this.registrationType, other.registrationType)
+                && Objects.equals(this.location, other.location)
                 && Objects.equals(this.businessType, other.businessType)
                 && Objects.equals(this.otherBusinesses, other.otherBusinesses)
                 && Objects.equals(this.isMainService, other.isMainService)
@@ -801,7 +820,7 @@ public class Registration
     @Override
     public int hashCode()
     {
-        return Objects.hash(tier, registrationType, businessType, otherBusinesses, isMainService, constructionWaste,
+        return Objects.hash(tier, registrationType, location, businessType, otherBusinesses, isMainService, constructionWaste,
                 onlyAMF, companyName, individualsType, publicBodyType, publicBodyTypeOther, companyNo,
                 title, otherTitle, firstName, lastName, position, phoneNumber, contactEmail, totalFee, registrationFee,
                 copyCardFee, copyCards, accountEmail, declaredConvictions, declaration, expires_on, originalRegistrationNumber

--- a/src/test/java/uk/gov/ea/wastecarrier/services/support/RegistrationBuilder.java
+++ b/src/test/java/uk/gov/ea/wastecarrier/services/support/RegistrationBuilder.java
@@ -27,6 +27,7 @@ public class RegistrationBuilder {
     private Boolean includeCopyCard = false;
 
     private String regIdentifier;
+    private String location = "england";
     private String businessType = "soleTrader";
     private String companyName;
     private String lastName = "Isaacs";
@@ -63,6 +64,11 @@ public class RegistrationBuilder {
 
     public RegistrationBuilder regIdentifier(String regIdentifier) {
         this.regIdentifier = regIdentifier;
+        return this;
+    }
+
+    public RegistrationBuilder location(String location) {
+        this.location = location;
         return this;
     }
 
@@ -160,6 +166,7 @@ public class RegistrationBuilder {
         Registration reg = new Registration();
 
         reg.setUuid(generateUUID());
+        reg.setLocation(this.location);
         reg.setBusinessType(this.businessType);
         reg.setCompanyName(generateCompanyName());
         reg.setFirstName("Jason");


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-214

As part of building the renewals service we added support for a location question. The main purpose is to

- ensure that the user is registered with the right authority
- reduce the burden on EA staff having to check for users based elsewhere who have registered with us, who they then have to confirm if this is correct.

The Waste Carriers frontend has been updated in [PR #182](https://github.com/DEFRA/waste-carriers-frontend/pull/182) to include the location question as part of the new registration journey. However as the Waste Carriers Service sits between the frontend and the database, it needs to be updated to support this new attribute.