### PR TITLE
Update travis.yml to run unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_script:
   - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then chmod +x ./cc-test-reporter; fi
   - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then ./cc-test-reporter before-build; fi
 
-script: ./mvnw -B -T 1C clean package
+script: ./mvnw -B -T 1C clean test package
 
 after_script:
   # In order to get this to work found we could not use the standard


### PR DESCRIPTION
To reduce the time it takes to run `mvn package` generally we have maven setup to not run unit tests automatically. However we've overlooked the fact this means the tests don't get run in CI.

This change rectifies the situation.