### PR TITLE
Switch to SonarCloud from CodeClimate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,23 @@
-env:
-  global:
-    - CC_TEST_REPORTER_ID=2bdee2bd9c064b9353a674904c20c8047c95ac1c15b7580a141203d684ef5687
-    - WCRS_TEST_REGSDB_URI="mongodb://mongoUser:password1234@localhost:27017/waste-carriers-test"
-    - WCRS_TEST_USERSDB_URI="mongodb://mongoUser:password1234@localhost:27017/waste-carriers-users-test"
-    - WCRS_TEST_MONGODB_SERVER_SEL_TIMEOUT=1000
+addons:
+  sonarcloud:
+    organization: "defra"
 
 language: java
 
 jdk:
   - openjdk8
 
-# Travis CI clones repositories to a depth of 50 commits, which is only really
-# useful if you are performing git operations.
-# https://docs.travis-ci.com/user/customizing-the-build/#Git-Clone-Depth
+# Travis CI uses shallow clone to speed up build times, but a truncated SCM
+# history may cause issues when SonarCloud computes blame data. To avoid this,
+# you can access the full SCM history with `depth: false`
 git:
-  depth: 3
+  depth: false
+
+env:
+  global:
+    - WCRS_TEST_REGSDB_URI="mongodb://mongoUser:password1234@localhost:27017/waste-carriers-test"
+    - WCRS_TEST_USERSDB_URI="mongodb://mongoUser:password1234@localhost:27017/waste-carriers-users-test"
+    - WCRS_TEST_MONGODB_SERVER_SEL_TIMEOUT=1000
 
 services:
   - mongodb
@@ -23,20 +26,15 @@ before_script:
   # Set up Mongo databases
   - mongo waste-carriers-test --eval 'db.createUser({user:"mongoUser", pwd:"password1234", roles:["readWrite", "dbAdmin", "userAdmin"]})'
   - mongo waste-carriers-users-test --eval 'db.createUser({user:"mongoUser", pwd:"password1234", roles:["readWrite", "dbAdmin", "userAdmin"]})'
-  # Setup to support the CodeClimate test coverage submission
-  # As per CodeClimate's documentation, they suggest only running
-  # ./cc-test-reporter commands on travis-ci push builds only. Hence we wrap all
-  # the codeclimate test coverage related commands in a check that tests if we
-  # are in a pull request or not.
-  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter; fi
-  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then chmod +x ./cc-test-reporter; fi
-  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then ./cc-test-reporter before-build; fi
 
-script: ./mvnw -B -T 1C clean test package
+script:
+  # the following command line builds the project, runs the tests with coverage and then execute the SonarCloud analysis
+  - ./mvnw -B -T 1C clean test org.jacoco:jacoco-maven-plugin:prepare-agent install sonar:sonar -Dsonar.projectKey=DEFRA_waste-carriers-service
+  # - ./mvnw -B -T 1C clean test package
 
-after_script:
-  # In order to get this to work found we could not use the standard
-  # ./cc-test-reporter after-build but instead have to use the lower level cmds
-  # format-coverage and upload-coverage. Solved this only after finding
-  # https://github.com/codeclimate/test-reporter/issues/259#issuecomment-374280649
-  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then JACOCO_SOURCE_PATH=src/main/java ./cc-test-reporter format-coverage target/jacoco/jacoco.xml --input-type jacoco && ./cc-test-reporter upload-coverage; fi
+# after_script:
+#   # In order to get this to work found we could not use the standard
+#   # ./cc-test-reporter after-build but instead have to use the lower level cmds
+#   # format-coverage and upload-coverage. Solved this only after finding
+#   # https://github.com/codeclimate/test-reporter/issues/259#issuecomment-374280649
+#   - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then JACOCO_SOURCE_PATH=src/main/java ./cc-test-reporter format-coverage target/jacoco/jacoco.xml --input-type jacoco && ./cc-test-reporter upload-coverage; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,11 +30,3 @@ before_script:
 script:
   # the following command line builds the project, runs the tests with coverage and then execute the SonarCloud analysis
   - ./mvnw clean test org.jacoco:jacoco-maven-plugin:prepare-agent install sonar:sonar -Dsonar.projectKey=DEFRA_waste-carriers-service
-  # - ./mvnw -B -T 1C clean test package
-
-# after_script:
-#   # In order to get this to work found we could not use the standard
-#   # ./cc-test-reporter after-build but instead have to use the lower level cmds
-#   # format-coverage and upload-coverage. Solved this only after finding
-#   # https://github.com/codeclimate/test-reporter/issues/259#issuecomment-374280649
-#   - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then JACOCO_SOURCE_PATH=src/main/java ./cc-test-reporter format-coverage target/jacoco/jacoco.xml --input-type jacoco && ./cc-test-reporter upload-coverage; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_script:
 
 script:
   # the following command line builds the project, runs the tests with coverage and then execute the SonarCloud analysis
-  - ./mvnw -B -T 1C clean test org.jacoco:jacoco-maven-plugin:prepare-agent install sonar:sonar -Dsonar.projectKey=DEFRA_waste-carriers-service
+  - ./mvnw clean test org.jacoco:jacoco-maven-plugin:prepare-agent install sonar:sonar -Dsonar.projectKey=DEFRA_waste-carriers-service
   # - ./mvnw -B -T 1C clean test package
 
 # after_script:


### PR DESCRIPTION
https://sonarcloud.io/organizations/defra/projects

We currently use [Code Climate](https://codeclimate.com/) for our code quality checks and test coverage analysis. However a number of Defra projects have used an internal SonarQube instance, and some public ones have been using SonarCloud (the cloud SASS version of SonarQube).

It looks like we're about to formally adopt SonarCloud and all projects will coalesce onto. So to keep on top of things and continue to be an example to others, we are working through our repos and switching them to SonarCloud.

** Notes

The figuring out of how to do this (because it wasn't straight forward!) was done in

- https://github.com/DEFRA/waste-exemptions-front-office/pull/317
- https://github.com/DEFRA/waste-exemptions-front-office/pull/318