### PR TITLE
Add sonar-project.properties file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Waste Carriers Service
 
-[![Build Status](https://travis-ci.com/DEFRA/waste-carriers-service.svg?branch=develop)](https://travis-ci.com/DEFRA/waste-carriers-service)
-[![Maintainability](https://api.codeclimate.com/v1/badges/2931ee9159971050f098/maintainability)](https://codeclimate.com/github/DEFRA/waste-carriers-service/maintainability)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/2931ee9159971050f098/test_coverage)](https://codeclimate.com/github/DEFRA/waste-carriers-service/test_coverage)
+[![Build Status](https://travis-ci.com/DEFRA/waste-carriers-service.svg?branch=master)](https://travis-ci.com/DEFRA/waste-carriers-service)
+[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_waste-carriers-service&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=DEFRA_waste-carriers-service)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_waste-carriers-service&metric=coverage)](https://sonarcloud.io/dashboard?id=DEFRA_waste-carriers-service)
+[![Licence](https://img.shields.io/badge/Licence-OGLv3-blue.svg)](http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3)
 
 Waste Carriers Registration Service application.
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,13 @@
+# Project key is required. You'll find it in the SonarCloud UI
+sonar.projectKey=DEFRA_waste-carriers-service
+sonar.organization=defra
+
+# This is the name and version displayed in the SonarCloud UI
+sonar.projectName=waste-carriers-service
+sonar.projectVersion=3.0.0
+
+# This will add the same links in the SonarCloud UI
+sonar.links.homepage=https://github.com/DEFRA/waste-carriers-service
+sonar.links.ci=https://travis-ci.com/DEFRA/waste-carriers-service
+sonar.links.scm=https://github.com/DEFRA/waste-carriers-service
+sonar.links.issue=https://github.com/DEFRA/ruby-services-team/issues


### PR DESCRIPTION
We didn't bother to add this in PR #52 as SonarCloud did appear to need any config to work with Java. However realised after the fact that there is info we include in the properties file it can't get.

So adding this here plus fixing the badges in the README.